### PR TITLE
Normative: Remove "Name" postfix.

### DIFF
--- a/displaynames.html
+++ b/displaynames.html
@@ -154,7 +154,7 @@
         1. Let _typeFields_ be _types_.[[&lt;_type_&gt;]].
         1. Assert: _typeFields_ is a Record (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots"></emu-xref>).
         1. <ins>If _type_ is `"language"`, then</ins>
-          1. <ins>Let _dialectHandling_ be ? GetOption(_options_, `"dialectHandling"`, `"string"`, &laquo; `"dialectName"`, `"standardName"` &raquo;, `"dialectName"`).</ins>
+          1. <ins>Let _dialectHandling_ be ? GetOption(_options_, `"dialectHandling"`, `"string"`, &laquo; `"dialect"`, `"standard"` &raquo;, `"dialect"`).</ins>
           1. <ins>Set _displayNames_.[[DialectHandling]] to _dialectHandling_.</ins>
           1. <ins>Let _typeFields_ be _typeFields_.[[&lt;_dialectHandling_&gt;]].</ins>
           1. <ins>Assert: _typeFields_ is a Record (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots"></emu-xref>).</ins>
@@ -215,7 +215,7 @@
 
       <ul>
         <li>[[LocaleData]].[[&lt;_locale_&gt;]] must have a [[types]] field for all locale values _locale_. The value of this field must be a Record, which must have fields with the names of one of the valid display name types: `"language"`, `"region"`, `"script"`, <del>and</del> `"currency"`<ins>, `"calendar"`, `"dateTimeField"`, and `"unit"`</ins>.</li>
-        <li><ins>The value of the field `"language"` must be a Record which must have fields with the names of one of the valid display name dialect handlings: `"dialectName"`, and `"standardName"`.</ins></li>
+        <li><ins>The value of the field `"language"` must be a Record which must have fields with the names of one of the valid display name dialect handlings: `"dialect"`, and `"standard"`.</ins></li>
         <li><ins>The display name dialect handling fields under display name type `"language"` should contain Records which must have fields with the names of one of the valid display name styles: `"narrow"`, `"short"`, and `"long"`.</ins></li>
         <li>The value of fields <del>`"language"`, </del>`"region"`, `"script"`, <del>and </del>`"currency"`<ins>, `"calendar"`, `"dateTimeField"`, and `"unit"`</ins> must be a Record which must have fields with the names of one of the valid display name styles: `"narrow"`, `"short"`, and `"long"`.</li>
         <li>The display name styles fields under display name type `"language"` should contain Records, with keys corresponding to language codes according to `unicode_language_id` production. The value of these fields must be string values.</li>
@@ -354,7 +354,7 @@
       <li>[[Style]] is one of the String values `"narrow"`, `"short"`, or `"long"`, identifying the display names style used.</li>
       <li>[[Type]] is one of the String values `"language"`, `"region"`, `"script"`, <del>or </del>`"currency"`,<ins> `"calendar"`, `"dateTimeField"`, or `"unit"`,</ins> identifying the type of the display names requested.</li>
       <li>[[Fallback]] is one of the String values `"code"`, or `"none"`, identifying the fallback return when the system does not have the requested display name.</li>
-      <li><ins>[[DialectHandling]] is one of the String values `"dialectName"`, or `"standardName"`, identifying the display names dialect handling while and only while the [[Type]] is `"language"`.</ins></li>
+      <li><ins>[[DialectHandling]] is one of the String values `"dialect"`, or `"standard"`, identifying the display names dialect handling while and only while the [[Type]] is `"language"`.</ins></li>
       <li>[[Fields]] is a Record (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots"></emu-xref>) which
         must have fields with keys corresponding to codes according to [[Style]] <del>and</del><ins>,</ins> [[Type]]<ins>, and [[DialectHandling]]</ins>.</li>
     </ul>

--- a/index.html
+++ b/index.html
@@ -3,20 +3,25 @@
 <link rel="stylesheet" href="./spec.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
 <script src="./spec.js"></script>
-<title>Intl.DisplayNames v2 Proposal</title><script type="application/json" id="menu-search-biblio">[{"type":"clause","id":"sec-intro","aoid":null,"title":"Introduction","titleHTML":"Introduction","number":"","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Introduction"},{"type":"op","aoid":"CanonicalCodeForDisplayNames","refId":"sec-canonicalcodefordisplaynames","location":"","referencingIds":[],"key":"CanonicalCodeForDisplayNames"},{"type":"clause","id":"sec-canonicalcodefordisplaynames","aoid":"CanonicalCodeForDisplayNames","title":"CanonicalCodeForDisplayNames ( type, code)","titleHTML":"CanonicalCodeForDisplayNames ( <var>type</var>, <var>code</var>)","number":"1.1.1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":["_ref_13"],"key":"CanonicalCodeForDisplayNames ( type, code)"},{"type":"clause","id":"sec-intl-displaynames-abstracts","aoid":null,"title":"Abstract Operations for DisplayNames Objects","titleHTML":"Abstract Operations for DisplayNames Objects","number":"1.1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Abstract Operations for DisplayNames Objects"},{"type":"table","id":"table-validcodefordatetimefield","number":1,"caption":"Table 1: <ins>Codes For Date Time Field of DisplayNames</ins>","referencingIds":["_ref_0","_ref_5"],"namespace":"https://tc39.es/intl-displaynames-v2/","location":"","key":"Table 1: <ins>Codes For Date Time Field of DisplayNames</ins>"},{"type":"op","aoid":"IsValidDateTimeFieldCode","refId":"sec-isvaliddatetimefieldcode","location":"","referencingIds":[],"key":"IsValidDateTimeFieldCode"},{"type":"clause","id":"sec-isvaliddatetimefieldcode","aoid":"IsValidDateTimeFieldCode","title":"IsValidDateTimeFieldCode ( field )","titleHTML":"<ins>IsValidDateTimeFieldCode ( <var>field</var> )</ins>","number":"1.2","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":["_ref_8"],"key":"IsValidDateTimeFieldCode ( field )"},{"type":"clause","id":"sec-Intl.DisplayNames","aoid":null,"title":"Intl.DisplayNames ( locales, options )","titleHTML":"Intl.DisplayNames ( <var>locales</var>, <var>options</var> )","number":"1.3.1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames ( locales, options )"},{"type":"clause","id":"sec-intl-displaynames-constructor","aoid":null,"title":"The Intl.DisplayNames Constructor","titleHTML":"The Intl.DisplayNames Constructor","number":"1.3","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"The Intl.DisplayNames Constructor"},{"type":"clause","id":"sec-Intl.DisplayNames.prototype","aoid":null,"title":"Intl.DisplayNames.prototype","titleHTML":"Intl.DisplayNames.prototype","number":"1.4.1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype"},{"type":"clause","id":"sec-Intl.DisplayNames.supportedLocalesOf","aoid":null,"title":"Intl.DisplayNames.supportedLocalesOf ( locales [ , options ] )","titleHTML":"Intl.DisplayNames.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )","number":"1.4.2","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.supportedLocalesOf ( locales [ , options ] )"},{"type":"clause","id":"sec-Intl.DisplayNames-internal-slots","aoid":null,"title":"Internal slots","titleHTML":"Internal slots","number":"1.4.3","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":["_ref_1","_ref_2","_ref_3","_ref_4","_ref_7"],"key":"Internal slots"},{"type":"clause","id":"sec-properties-of-intl-displaynames-constructor","aoid":null,"title":"Properties of the Intl.DisplayNames Constructor","titleHTML":"Properties of the Intl.DisplayNames Constructor","number":"1.4","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Properties of the Intl.DisplayNames Constructor"},{"type":"clause","id":"sec-Intl.DisplayNames.prototype.constructor","aoid":null,"title":"Intl.DisplayNames.prototype.constructor","titleHTML":"Intl.DisplayNames.prototype.constructor","number":"1.5.1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype.constructor"},{"type":"clause","id":"sec-Intl.DisplayNames.prototype-@@tostringtag","aoid":null,"title":"Intl.DisplayNames.prototype[ @@toStringTag ]","titleHTML":"Intl.DisplayNames.prototype[ @@toStringTag ]","number":"1.5.2","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype[ @@toStringTag ]"},{"type":"op","aoid":"Intl.DisplayNames.prototype.of","refId":"sec-Intl.DisplayNames.prototype.of","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype.of"},{"type":"clause","id":"sec-Intl.DisplayNames.prototype.of","aoid":"Intl.DisplayNames.prototype.of","title":"Intl.DisplayNames.prototype.of ( code )","titleHTML":"Intl.DisplayNames.prototype.of ( <var>code</var> )","number":"1.5.3","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype.of ( code )"},{"type":"table","id":"table-displaynames-resolvedoptions-properties","number":2,"caption":"Table 2: Resolved Options of DisplayNames Instances","referencingIds":["_ref_6"],"namespace":"https://tc39.es/intl-displaynames-v2/","location":"","key":"Table 2: Resolved Options of DisplayNames Instances"},{"type":"clause","id":"sec-Intl.DisplayNames.prototype.resolvedOptions","aoid":null,"title":"Intl.DisplayNames.prototype.resolvedOptions ( )","titleHTML":"Intl.DisplayNames.prototype.resolvedOptions ( )","number":"1.5.4","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype.resolvedOptions ( )"},{"type":"clause","id":"sec-properties-of-intl-displaynames-prototype-object","aoid":null,"title":"Properties of the Intl.DisplayNames Prototype Object","titleHTML":"Properties of the Intl.DisplayNames Prototype Object","number":"1.5","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Properties of the Intl.DisplayNames Prototype Object"},{"type":"clause","id":"sec-properties-of-intl-displaynames-instances","aoid":null,"title":"Properties of Intl.DisplayNames Instances","titleHTML":"Properties of Intl.DisplayNames Instances","number":"1.6","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Properties of Intl.DisplayNames Instances"},{"type":"clause","id":"intl-displaynames-objects","aoid":null,"title":"DisplayNames Objects","titleHTML":"DisplayNames Objects","number":"1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"DisplayNames Objects"},{"type":"clause","id":"sec-copyright-and-software-license","aoid":null,"title":"Copyright & Software License","titleHTML":"Copyright &amp; Software License","number":"A","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Copyright & Software License"}]</script><script>"use strict";
+<title>Intl.DisplayNames v2 Proposal</title><script type="application/json" id="menu-search-biblio">[{"type":"clause","id":"sec-intro","aoid":null,"title":"Introduction","titleHTML":"Introduction","number":"","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Introduction"},{"type":"op","aoid":"CanonicalCodeForDisplayNames","refId":"sec-canonicalcodefordisplaynames","location":"","referencingIds":[],"key":"CanonicalCodeForDisplayNames"},{"type":"clause","id":"sec-canonicalcodefordisplaynames","aoid":"CanonicalCodeForDisplayNames","title":"CanonicalCodeForDisplayNames ( type, code)","titleHTML":"CanonicalCodeForDisplayNames ( <var>type</var>, <var>code</var>)","number":"1.1.1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":["_ref_13"],"key":"CanonicalCodeForDisplayNames ( type, code)"},{"type":"clause","id":"sec-intl-displaynames-abstracts","aoid":null,"title":"Abstract Operations for DisplayNames Objects","titleHTML":"Abstract Operations for DisplayNames Objects","number":"1.1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Abstract Operations for DisplayNames Objects"},{"type":"table","id":"table-validcodefordatetimefield","node":{},"number":1,"caption":"Table 1: <ins>Codes For Date Time Field of DisplayNames</ins>","referencingIds":["_ref_0","_ref_5"],"namespace":"https://tc39.es/intl-displaynames-v2/","location":"","key":"Table 1: <ins>Codes For Date Time Field of DisplayNames</ins>"},{"type":"op","aoid":"IsValidDateTimeFieldCode","refId":"sec-isvaliddatetimefieldcode","location":"","referencingIds":[],"key":"IsValidDateTimeFieldCode"},{"type":"clause","id":"sec-isvaliddatetimefieldcode","aoid":"IsValidDateTimeFieldCode","title":"IsValidDateTimeFieldCode ( field )","titleHTML":"<ins>IsValidDateTimeFieldCode ( <var>field</var> )</ins>","number":"1.2","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":["_ref_8"],"key":"IsValidDateTimeFieldCode ( field )"},{"type":"clause","id":"sec-Intl.DisplayNames","aoid":null,"title":"Intl.DisplayNames ( locales, options )","titleHTML":"Intl.DisplayNames ( <var>locales</var>, <var>options</var> )","number":"1.3.1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames ( locales, options )"},{"type":"clause","id":"sec-intl-displaynames-constructor","aoid":null,"title":"The Intl.DisplayNames Constructor","titleHTML":"The Intl.DisplayNames Constructor","number":"1.3","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"The Intl.DisplayNames Constructor"},{"type":"clause","id":"sec-Intl.DisplayNames.prototype","aoid":null,"title":"Intl.DisplayNames.prototype","titleHTML":"Intl.DisplayNames.prototype","number":"1.4.1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype"},{"type":"clause","id":"sec-Intl.DisplayNames.supportedLocalesOf","aoid":null,"title":"Intl.DisplayNames.supportedLocalesOf ( locales [ , options ] )","titleHTML":"Intl.DisplayNames.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )","number":"1.4.2","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.supportedLocalesOf ( locales [ , options ] )"},{"type":"clause","id":"sec-Intl.DisplayNames-internal-slots","aoid":null,"title":"Internal slots","titleHTML":"Internal slots","number":"1.4.3","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":["_ref_1","_ref_2","_ref_3","_ref_4","_ref_7"],"key":"Internal slots"},{"type":"clause","id":"sec-properties-of-intl-displaynames-constructor","aoid":null,"title":"Properties of the Intl.DisplayNames Constructor","titleHTML":"Properties of the Intl.DisplayNames Constructor","number":"1.4","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Properties of the Intl.DisplayNames Constructor"},{"type":"clause","id":"sec-Intl.DisplayNames.prototype.constructor","aoid":null,"title":"Intl.DisplayNames.prototype.constructor","titleHTML":"Intl.DisplayNames.prototype.constructor","number":"1.5.1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype.constructor"},{"type":"clause","id":"sec-Intl.DisplayNames.prototype-@@tostringtag","aoid":null,"title":"Intl.DisplayNames.prototype[ @@toStringTag ]","titleHTML":"Intl.DisplayNames.prototype[ @@toStringTag ]","number":"1.5.2","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype[ @@toStringTag ]"},{"type":"op","aoid":"Intl.DisplayNames.prototype.of","refId":"sec-Intl.DisplayNames.prototype.of","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype.of"},{"type":"clause","id":"sec-Intl.DisplayNames.prototype.of","aoid":"Intl.DisplayNames.prototype.of","title":"Intl.DisplayNames.prototype.of ( code )","titleHTML":"Intl.DisplayNames.prototype.of ( <var>code</var> )","number":"1.5.3","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype.of ( code )"},{"type":"table","id":"table-displaynames-resolvedoptions-properties","node":{},"number":2,"caption":"Table 2: Resolved Options of DisplayNames Instances","referencingIds":["_ref_6"],"namespace":"https://tc39.es/intl-displaynames-v2/","location":"","key":"Table 2: Resolved Options of DisplayNames Instances"},{"type":"clause","id":"sec-Intl.DisplayNames.prototype.resolvedOptions","aoid":null,"title":"Intl.DisplayNames.prototype.resolvedOptions ( )","titleHTML":"Intl.DisplayNames.prototype.resolvedOptions ( )","number":"1.5.4","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype.resolvedOptions ( )"},{"type":"clause","id":"sec-properties-of-intl-displaynames-prototype-object","aoid":null,"title":"Properties of the Intl.DisplayNames Prototype Object","titleHTML":"Properties of the Intl.DisplayNames Prototype Object","number":"1.5","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Properties of the Intl.DisplayNames Prototype Object"},{"type":"clause","id":"sec-properties-of-intl-displaynames-instances","aoid":null,"title":"Properties of Intl.DisplayNames Instances","titleHTML":"Properties of Intl.DisplayNames Instances","number":"1.6","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Properties of Intl.DisplayNames Instances"},{"type":"clause","id":"intl-displaynames-objects","aoid":null,"title":"DisplayNames Objects","titleHTML":"DisplayNames Objects","number":"1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"DisplayNames Objects"},{"type":"clause","id":"sec-copyright-and-software-license","aoid":null,"title":"Copyright & Software License","titleHTML":"Copyright &amp; Software License","number":"A","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Copyright & Software License"}]</script><script>"use strict";
 
 function Search(menu) {
   this.menu = menu;
   this.$search = document.getElementById('menu-search');
   this.$searchBox = document.getElementById('menu-search-box');
   this.$searchResults = document.getElementById('menu-search-results');
-  
+
   this.loadBiblio();
-  
+
   document.addEventListener('keydown', this.documentKeydown.bind(this));
-  
+
   this.$searchBox.addEventListener('keydown', debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true }));
   this.$searchBox.addEventListener('keyup', debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true }));
+
+  // Perform an initial search if the box is not empty.
+  if (this.$searchBox.value) {
+    this.search(this.$searchBox.value);
+  }
 }
 
 Search.prototype.loadBiblio = function () {
@@ -56,7 +61,7 @@ Search.prototype.searchBoxKeyup = function (e) {
   if (e.keyCode === 13 || e.keyCode === 9) {
     return;
   }
-  
+
   this.search(e.target.value);
 }
 
@@ -79,25 +84,23 @@ Search.prototype.triggerSearch = function (e) {
 // prefer shorter matches.
 function relevance(result, searchString) {
   var relevance = 0;
-  
+
   relevance = Math.max(0, 8 - result.match.chunks) << 7;
-  
+
   if (result.match.caseMatch) {
     relevance *= 2;
   }
-  
+
   if (result.match.prefix) {
     relevance += 2048
   }
-  
+
   relevance += Math.max(0, 255 - result.entry.key.length);
-  
+
   return relevance;
 }
 
 Search.prototype.search = function (searchString) {
-  var s = Date.now();
-
   if (searchString === '') {
     this.displayResults([]);
     this.hideSearch();
@@ -105,12 +108,12 @@ Search.prototype.search = function (searchString) {
   } else {
     this.showSearch();
   }
-  
+
   if (searchString.length === 1) {
     this.displayResults([]);
     return;
   }
-    
+
   var results;
 
   if (/^[\d\.]*$/.test(searchString)) {
@@ -121,7 +124,7 @@ Search.prototype.search = function (searchString) {
     });
   } else {
     results = [];
-    
+
     for (var i = 0; i < this.biblio.length; i++) {
       var entry = this.biblio[i];
       if (!entry.key) {
@@ -134,11 +137,11 @@ Search.prototype.search = function (searchString) {
         results.push({ entry: entry, match: match });
       }
     }
-  
+
     results.forEach(function (result) {
       result.relevance = relevance(result, searchString);
     });
-    
+
     results = results.sort(function (a, b) { return b.relevance - a.relevance });
 
   }
@@ -146,7 +149,7 @@ Search.prototype.search = function (searchString) {
   if (results.length > 50) {
     results = results.slice(0, 50);
   }
-  
+
   this.displayResults(results);
 }
 Search.prototype.hideSearch = function () {
@@ -163,7 +166,7 @@ Search.prototype.selectResult = function () {
   if ($first) {
     document.location = $first.getAttribute('href');
   }
-  
+
   this.$searchBox.value = '';
   this.$searchBox.blur();
   this.displayResults([]);
@@ -177,7 +180,7 @@ Search.prototype.selectResult = function () {
 Search.prototype.displayResults = function (results) {
   if (results.length > 0) {
     this.$searchResults.classList.remove('no-results');
-    
+
     var html = '<ul>';
 
     results.forEach(function (result) {
@@ -194,7 +197,7 @@ Search.prototype.displayResults = function (results) {
       } else if (entry.type === 'production') {
         text = entry.key;
         cssClass = 'prod';
-        id = entry.id;  
+        id = entry.id;
       } else if (entry.type === 'op') {
         text = entry.key;
         cssClass = 'op';
@@ -206,7 +209,7 @@ Search.prototype.displayResults = function (results) {
       }
 
       if (text) {
-        html += '<li class=menu-search-result-' + cssClass + '><a href="#' + id + '">' + text + '</a></li>'
+        html += '<li class=menu-search-result-' + cssClass + '><a href="#' + id + '">' + text + '</a></li>';
       }
     });
 
@@ -229,7 +232,7 @@ function Menu() {
   this.$toc = document.querySelector('#menu-toc > ol');
   this.$specContainer = document.getElementById('spec-container');
   this.search = new Search(this);
-  
+
   this._pinnedIds = {}; 
   this.loadPinEntries();
 
@@ -274,9 +277,9 @@ function Menu() {
                     && target.offsetHeight + target.scrollTop >= target.scrollHeight;
 
     if (offBottom) {
-		  e.preventDefault();
-	  }
-  })
+      e.preventDefault();
+    }
+  });
 }
 
 Menu.prototype.documentKeydown = function (e) {
@@ -303,7 +306,7 @@ Menu.prototype.revealInToc = function (path) {
     current[i].classList.remove('revealed');
     current[i].classList.remove('revealed-leaf');
   }
-  
+
   var current = this.$toc;
   var index = 0;
   while (index < path.length) {
@@ -314,7 +317,7 @@ Menu.prototype.revealInToc = function (path) {
         if (index === path.length - 1) {
           children[i].classList.add('revealed-leaf');
           var rect = children[i].getBoundingClientRect();
-          this.$toc.getBoundingClientRect().top
+          // this.$toc.getBoundingClientRect().top;
           var tocRect = this.$toc.getBoundingClientRect();
           if (rect.top + 10 > tocRect.bottom) {
             this.$toc.scrollTop = this.$toc.scrollTop + (rect.top - tocRect.bottom) + (rect.bottom - rect.top);
@@ -325,29 +328,27 @@ Menu.prototype.revealInToc = function (path) {
         current = children[i].querySelector('ol');
         index++;
         break;
-      }      
+      }
     }
-    
+
   }
 }
 
 function findActiveClause(root, path) {
   var clauses = new ClauseWalker(root);
   var $clause;
-  var found = false;
   var path = path || [];
-  
+
   while ($clause = clauses.nextNode()) {
     var rect = $clause.getBoundingClientRect();
-    var $header = $clause.children[0];
+    var $header = $clause.querySelector("h1");
     var marginTop = parseInt(getComputedStyle($header)["margin-top"]);
-    
+
     if ((rect.top - marginTop) <= 0 && rect.bottom > 0) {
-      found = true;
       return findActiveClause($clause, path.concat($clause)) || path;
     }
   }
-  
+
   return path;
 }
 
@@ -372,7 +373,7 @@ function ClauseWalker(root) {
     },
     false
     );
-  
+
   return treeWalker;
 }
 
@@ -455,7 +456,7 @@ Menu.prototype.loadPinEntries = function () {
   } catch (e) {
     return;
   }
-  
+
   var pinsString = window.localStorage.pinEntries;
   if (!pinsString) return;
   var pins = JSON.parse(pinsString);
@@ -486,6 +487,11 @@ function init() {
   var $container = document.getElementById('spec-container');
   $container.addEventListener('mouseover', debounce(function (e) {
     Toolbox.activateIfMouseOver(e);
+  }));
+  document.addEventListener('keydown', debounce(function (e) {
+    if (e.code === "Escape" && Toolbox.active) {
+      Toolbox.deactivate();
+    }
   }));
 }
 
@@ -585,12 +591,11 @@ function fuzzysearch (searchString, haystack, caseInsensitive) {
   var qlen = searchString.length;
   var chunks = 1;
   var finding = false;
-  var prefix = true;
-  
+
   if (qlen > tlen) {
     return false;
   }
-  
+
   if (qlen === tlen) {
     if (searchString === haystack) {
       return { caseMatch: true, chunks: 1, prefix: true };
@@ -600,7 +605,7 @@ function fuzzysearch (searchString, haystack, caseInsensitive) {
       return false;
     }
   }
-  
+
   outer: for (var i = 0, j = 0; i < qlen; i++) {
     var nch = searchString[i];
     while (j < tlen) {
@@ -614,12 +619,12 @@ function fuzzysearch (searchString, haystack, caseInsensitive) {
         finding = false;
       }
     }
-    
-    if (caseInsensitive) { return false }
-    
+
+    if (caseInsensitive) { return false; }
+
     return fuzzysearch(searchString.toLowerCase(), haystack.toLowerCase(), true);
   }
-  
+
   return { caseMatch: !caseInsensitive, chunks: chunks, prefix: j <= qlen };
 }
 
@@ -776,7 +781,6 @@ var referencePane = {
       var target = document.getElementById(id);
       var cid = findParentClauseId(target);
       var clause = menu.search.biblio.byId[cid];
-      var dupCount = 0;
       return { id: id, clause: clause }
     }).sort(function (a, b) {
       return sortByClauseNumber(a.clause, b.clause);
@@ -816,7 +820,7 @@ function sortByClauseNumber(c1, c2) {
     if (i >= c2c.length) {
       return 1;
     }
-    
+
     var c1 = c1c[i];
     var c2 = c2c[i];
     var c1cn = Number(c1);
@@ -976,16 +980,43 @@ emu-const {
 emu-val {
   font-weight: bold;
 }
-emu-alg ol, emu-alg ol ol ol ol {
-    list-style-type: decimal;
+
+/* depth 1 */
+emu-alg ol,
+/* depth 4 */
+emu-alg ol ol ol ol,
+emu-alg ol.nested-thrice,
+emu-alg ol.nested-twice ol,
+emu-alg ol.nested-once ol ol {
+  list-style-type: decimal;
 }
 
-emu-alg ol ol, emu-alg ol ol ol ol ol {
-    list-style-type: lower-alpha;
+/* depth 2 */
+emu-alg ol ol,
+emu-alg ol.nested-once,
+/* depth 5 */
+emu-alg ol ol ol ol ol,
+emu-alg ol.nested-four-times,
+emu-alg ol.nested-thrice ol,
+emu-alg ol.nested-twice ol ol,
+emu-alg ol.nested-once ol ol ol {
+  list-style-type: lower-alpha;
 }
 
-emu-alg ol ol ol, ol ol ol ol ol ol {
-    list-style-type: lower-roman;
+/* depth 3 */
+emu-alg ol ol ol,
+emu-alg ol.nested-twice,
+emu-alg ol.nested-once ol,
+/* depth 6 */
+emu-alg ol ol ol ol ol ol,
+emu-alg ol.nested-lots,
+emu-alg ol.nested-four-times ol,
+emu-alg ol.nested-thrice ol ol,
+emu-alg ol.nested-twice ol ol ol,
+emu-alg ol.nested-once ol ol ol ol,
+/* depth 7+ */
+emu-alg ol.nested-lots ol {
+  list-style-type: lower-roman;
 }
 
 emu-eqn {
@@ -1036,6 +1067,10 @@ emu-note > div.note-contents > p:last-of-type {
   margin-bottom: 0;
 }
 
+emu-table td code {
+  white-space: normal;
+} 
+
 emu-figure {
   display: block;
 }
@@ -1060,6 +1095,10 @@ emu-table figure {
 
 emu-production {
     display: block;
+}
+
+emu-grammar[type="example"] emu-production,
+emu-grammar[type="definition"] emu-production {
     margin-top: 1em;
     margin-bottom: 1em;
     margin-left: 5ex;
@@ -1067,9 +1106,15 @@ emu-production {
 
 emu-grammar.inline, emu-production.inline,
 emu-grammar.inline emu-production emu-rhs, emu-production.inline emu-rhs,
-emu-grammar[collapsed] emu-production emu-rhs, emu-production[collapsed] emu-rhs {
+emu-grammar[collapsed] emu-production emu-rhs {
     display: inline;
     padding-left: 1ex;
+    margin-left: 0;
+}
+
+emu-production[collapsed] emu-rhs {
+    display: inline;
+    padding-left: .5ex;
     margin-left: 0;
 }
 
@@ -1079,26 +1124,27 @@ emu-grammar[collapsed] emu-production, emu-production[collapsed] {
 
 emu-constraints {
     font-size: .75em;
-    margin-right: 1ex;
+    margin-right: .5ex;
 }
 
 emu-gann {
-    margin-right: 1ex;
+    margin-right: .5ex;
 }
 
 emu-gann emu-t:last-child,
+emu-gann emu-gprose:last-child,
 emu-gann emu-nt:last-child {
     margin-right: 0;
 }
 
 emu-geq {
-    margin-left: 1ex;
+    margin-left: .5ex;
     font-weight: bold;
 }
 
 emu-oneof {
     font-weight: bold;
-    margin-left: 1ex;
+    margin-left: .5ex;
 }
 
 emu-nt {
@@ -1113,7 +1159,7 @@ emu-nt a, emu-nt a:visited {
 }
 
 emu-rhs emu-nt {
-    margin-right: 1ex;
+    margin-right: .5ex;
 }
 
 emu-t {
@@ -1125,7 +1171,7 @@ emu-t {
 }
 
 emu-production emu-t {
-    margin-right: 1ex;
+    margin-right: .5ex;
 }
 
 emu-rhs {
@@ -1139,10 +1185,6 @@ emu-mods {
     vertical-align: sub;
     font-style: normal;
     font-weight: normal;
-}
-
-emu-production[collapsed] emu-mods {
-  display: none;
 }
 
 emu-params, emu-opt {
@@ -1161,6 +1203,10 @@ emu-opt {
 emu-gprose {
     font-size: 0.9em;
     font-family: Helvetica, Arial, sans-serif;
+}
+
+emu-production emu-gprose {
+    margin-right: 1ex;
 }
 
 h1.shortname {
@@ -1190,7 +1236,7 @@ h1, h2, h3, h4, h5, h6 {
 
 h1 .secnum {
   text-decoration: none;
-  margin-right: 10px;
+  margin-right: 5px;
 }
 
 h1 span.title {
@@ -1811,40 +1857,35 @@ li.menu-search-result-term:before {
   <h1>Introduction</h1>
 
   <p>This proposal enhances the Intl.DisplayNames API and cover more display names for weekday, month, time zone, unit, calendar, numbering system, etc.
-  See  <a href="https://github.com/tc39/intl-displaynames-v2/blob/main/README.md">the README</a> for more context.</p>
+  See <a href="https://github.com/tc39/intl-displaynames-v2/blob/main/README.md">the README</a> for more context.</p>
 </emu-intro>
 
 <emu-biblio href="./biblio.json"></emu-biblio>
-<emu-import href="./displaynames.html"><emu-biblio href="./biblio.json"></emu-biblio>
-<emu-clause id="intl-displaynames-objects">
-  <h1><span class="secnum">1</span>DisplayNames Objects</h1>
+<emu-import href="./displaynames.html"><emu-biblio href="./biblio.json"></emu-biblio><emu-clause id="intl-displaynames-objects">
+  <h1><span class="secnum">1</span> DisplayNames Objects</h1>
 
   <emu-clause id="sec-intl-displaynames-abstracts">
-    <h1><span class="secnum">1.1</span>Abstract Operations for DisplayNames Objects</h1>
+    <h1><span class="secnum">1.1</span> Abstract Operations for DisplayNames Objects</h1>
 
     <emu-clause id="sec-canonicalcodefordisplaynames" aoid="CanonicalCodeForDisplayNames">
-      <h1><span class="secnum">1.1.1</span>CanonicalCodeForDisplayNames ( <var>type</var>, <var>code</var>)</h1>
+      <h1><span class="secnum">1.1.1</span> CanonicalCodeForDisplayNames ( <var>type</var>, <var>code</var>)</h1>
       <p>
-      The CanonicalCodeForDisplayNames abstract operation is called with arguments <var>type</var>, <var>code</var>. It verifies that the <var>code</var> argument represents a well-formed code according to the <var>type</var> argument and returns the case-regularized form of the <var>code</var>. The algorithm refers to  <a href="https://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>. The following steps are taken:
-      
+      The CanonicalCodeForDisplayNames abstract operation is called with arguments <var>type</var>, <var>code</var>. It verifies that the <var>code</var> argument represents a well-formed code according to the <var>type</var> argument and returns the case-regularized form of the <var>code</var>. The algorithm refers to <a href="https://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>. The following steps are taken:
       </p>
-      <emu-alg><ol><li>If <var>type</var> is <code>"language"</code>, then<ol><li>If <var>code</var> does not matches the <code>unicode_language_id</code> production, throw a <emu-val>RangeError</emu-val> exceptipon.</li><li>If <emu-xref aoid="IsStructurallyValidLanguageTag"><a href="https://tc39.es/ecma402/#sec-isstructurallyvalidlanguagetag">IsStructurallyValidLanguageTag</a></emu-xref>(<var>code</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Set <var>code</var> to <emu-xref aoid="CanonicalizeUnicodeLocaleId"><a href="https://tc39.es/ecma402/#sec-canonicalizeunicodelocaleid">CanonicalizeUnicodeLocaleId</a></emu-xref>(<var>code</var>).</li><li>Return <var>code</var>.</li></ol></li><li>If <var>type</var> is <code>"region"</code>, then<ol><li>If <var>code</var> does not matches the <code>unicode_region_subtag</code> production, throw a <emu-val>RangeError</emu-val> exceptipon.</li><li>Let <var>code</var> be the result of mapping <var>code</var> to upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"><a href="https://tc39.es/ecma402/#sec-case-sensitivity-and-case-mapping">6.1</a></emu-xref>.</li><li>Return <var>code</var>.</li></ol></li><li>If <var>type</var> is <code>"script"</code>, then<ol><li>If <var>code</var> does not matches the <code>unicode_script_subtag</code> production, throw a <emu-val>RangeError</emu-val> exceptipon.</li><li>Let <var>code</var> be the result of mapping the first character in <var>code</var> to upper case, and mapping the second, third and fourth character in <var>code</var> to lower case, as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"><a href="https://tc39.es/ecma402/#sec-case-sensitivity-and-case-mapping">6.1</a></emu-xref>.</li><li>Return <var>code</var>.</li></ol></li><li><ins>If <var>type</var> is <code>"calendar"</code>, then</ins><ol><li><ins>If <var>code</var> does not match the Unicode Locale Identifier <code>type</code> nonterminal, throw a <emu-val>RangeError</emu-val> exception.</ins></li><li><ins>Let <var>code</var> be the result of mapping <var>code</var> to lower case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"><a href="https://tc39.es/ecma402/#sec-case-sensitivity-and-case-mapping">6.1</a></emu-xref>.</ins></li><li><ins>Return <var>code</var>.</ins></li></ol></li><li><ins>If <var>type</var> is <code>"unit"</code>, then</ins><ol><li><ins>If the result of <emu-xref aoid="IsWellFormedUnitIdentifier"><a href="https://tc39.es/ecma402/#sec-iswellformedunitidentifier">IsWellFormedUnitIdentifier</a></emu-xref>(<var>code</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</ins></li><li><ins>Return <var>code</var>.</ins></li></ol></li><li><ins>If <var>type</var> is <code>"dateTimeField"</code>, then</ins><ol><li><ins>If the result of <emu-xref aoid="IsValidDateTimeFieldCode" id="_ref_8"><a href="#sec-isvaliddatetimefieldcode">IsValidDateTimeFieldCode</a></emu-xref>(<var>code</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</ins></li><li><ins>Return <var>code</var>.</ins></li></ol></li><li>Assert: <var>type</var> is <code>"currency"</code>.</li><li>If !&nbsp;<emu-xref aoid="IsWellFormedCurrencyCode"><a href="https://tc39.es/ecma402/#sec-iswellformedcurrencycode">IsWellFormedCurrencyCode</a></emu-xref>(<var>code</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exceptipon.</li><li>Let <var>code</var> be the result of mapping <var>code</var> to upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"><a href="https://tc39.es/ecma402/#sec-case-sensitivity-and-case-mapping">6.1</a></emu-xref>.</li><li>Return <var>code</var>.
-      </li></ol></emu-alg>
+      <emu-alg><ol><li>If <var>type</var> is <code>"language"</code>, then<ol><li>If <var>code</var> does not matches the <code>unicode_language_id</code> production, throw a <emu-val>RangeError</emu-val> exceptipon.</li><li>If <emu-xref aoid="IsStructurallyValidLanguageTag"><a href="https://tc39.es/ecma402/#sec-isstructurallyvalidlanguagetag">IsStructurallyValidLanguageTag</a></emu-xref>(<var>code</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Set <var>code</var> to <emu-xref aoid="CanonicalizeUnicodeLocaleId"><a href="https://tc39.es/ecma402/#sec-canonicalizeunicodelocaleid">CanonicalizeUnicodeLocaleId</a></emu-xref>(<var>code</var>).</li><li>Return <var>code</var>.</li></ol></li><li>If <var>type</var> is <code>"region"</code>, then<ol><li>If <var>code</var> does not matches the <code>unicode_region_subtag</code> production, throw a <emu-val>RangeError</emu-val> exceptipon.</li><li>Let <var>code</var> be the result of mapping <var>code</var> to upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"><a href="https://tc39.es/ecma402/#sec-case-sensitivity-and-case-mapping">6.1</a></emu-xref>.</li><li>Return <var>code</var>.</li></ol></li><li>If <var>type</var> is <code>"script"</code>, then<ol><li>If <var>code</var> does not matches the <code>unicode_script_subtag</code> production, throw a <emu-val>RangeError</emu-val> exceptipon.</li><li>Let <var>code</var> be the result of mapping the first character in <var>code</var> to upper case, and mapping the second, third and fourth character in <var>code</var> to lower case, as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"><a href="https://tc39.es/ecma402/#sec-case-sensitivity-and-case-mapping">6.1</a></emu-xref>.</li><li>Return <var>code</var>.</li></ol></li><li><ins>If <var>type</var> is <code>"calendar"</code>, then</ins><ol><li><ins>If <var>code</var> does not match the Unicode Locale Identifier <code>type</code> nonterminal, throw a <emu-val>RangeError</emu-val> exception.</ins></li><li><ins>Let <var>code</var> be the result of mapping <var>code</var> to lower case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"><a href="https://tc39.es/ecma402/#sec-case-sensitivity-and-case-mapping">6.1</a></emu-xref>.</ins></li><li><ins>Return <var>code</var>.</ins></li></ol></li><li><ins>If <var>type</var> is <code>"unit"</code>, then</ins><ol><li><ins>If the result of <emu-xref aoid="IsWellFormedUnitIdentifier"><a href="https://tc39.es/ecma402/#sec-iswellformedunitidentifier">IsWellFormedUnitIdentifier</a></emu-xref>(<var>code</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</ins></li><li><ins>Return <var>code</var>.</ins></li></ol></li><li><ins>If <var>type</var> is <code>"dateTimeField"</code>, then</ins><ol><li><ins>If the result of <emu-xref aoid="IsValidDateTimeFieldCode" id="_ref_8"><a href="#sec-isvaliddatetimefieldcode">IsValidDateTimeFieldCode</a></emu-xref>(<var>code</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</ins></li><li><ins>Return <var>code</var>.</ins></li></ol></li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>type</var> is <code>"currency"</code>.</li><li>If !&nbsp;<emu-xref aoid="IsWellFormedCurrencyCode"><a href="https://tc39.es/ecma402/#sec-iswellformedcurrencycode">IsWellFormedCurrencyCode</a></emu-xref>(<var>code</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exceptipon.</li><li>Let <var>code</var> be the result of mapping <var>code</var> to upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"><a href="https://tc39.es/ecma402/#sec-case-sensitivity-and-case-mapping">6.1</a></emu-xref>.</li><li>Return <var>code</var>.</li></ol></emu-alg>
     </emu-clause>
   </emu-clause>
 
     <emu-clause id="sec-isvaliddatetimefieldcode" aoid="IsValidDateTimeFieldCode">
-      <h1><span class="secnum">1.2</span><ins>IsValidDateTimeFieldCode ( <var>field</var> )</ins></h1>
+      <h1><span class="secnum">1.2</span> <ins>IsValidDateTimeFieldCode ( <var>field</var> )</ins></h1>
       <p>
       <ins>
         The IsValidDateTimeFieldCode abstract operation is called with arguments <var>field</var>. It verifies that the <var>field</var> argument represents a valid date time field code. The following steps are taken:
-      
       </ins>
       </p>
-      <emu-alg><ol><li><ins>If <var>field</var> is listed in <emu-xref href="#table-validcodefordatetimefield" id="_ref_0"><a href="#table-validcodefordatetimefield">Table 1</a></emu-xref>, return <emu-val>true</emu-val>.</ins></li><li><ins>Return <emu-val>false</emu-val>.</ins>
-      </li></ol></emu-alg>
+      <emu-alg><ol><li><ins>If <var>field</var> is listed in <emu-xref href="#table-validcodefordatetimefield" id="_ref_0"><a href="#table-validcodefordatetimefield">Table 1</a></emu-xref>, return <emu-val>true</emu-val>.</ins></li><li><ins>Return <emu-val>false</emu-val>.</ins></li></ol></emu-alg>
 
-      <emu-table id="table-validcodefordatetimefield"><figure><figcaption>Table 1:  <ins>Codes For Date Time Field of DisplayNames</ins></figcaption>
+      <emu-table id="table-validcodefordatetimefield"><figure><figcaption>Table 1: <ins>Codes For Date Time Field of DisplayNames</ins></figcaption>
         
         <table class="real-table">
           <thead>
@@ -1907,148 +1948,129 @@ li.menu-search-result-term:before {
     </emu-clause>
 
   <emu-clause id="sec-intl-displaynames-constructor">
-    <h1><span class="secnum">1.3</span>The Intl.DisplayNames Constructor</h1>
+    <h1><span class="secnum">1.3</span> The Intl.DisplayNames Constructor</h1>
 
     <p>
-      The DisplayNames constructor is a standard built-in property of the Intl object.</p>
+      The DisplayNames <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> is a standard built-in property of the Intl object.</p>
 
     <emu-clause id="sec-Intl.DisplayNames">
-      <h1><span class="secnum">1.3.1</span>Intl.DisplayNames ( <var>locales</var>, <var>options</var> )</h1>
+      <h1><span class="secnum">1.3.1</span> Intl.DisplayNames ( <var>locales</var>, <var>options</var> )</h1>
 
       <p>
         When the <emu-val>Intl.DisplayNames</emu-val> function is called with arguments <var>locales</var> and <var>options</var>, the following steps are taken:
-      
       </p>
 
-      <emu-alg><ol><li>If NewTarget is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>displayNames</var> be ?&nbsp;<emu-xref aoid="OrdinaryCreateFromConstructor" id="_ref_9"><a href="https://tc39.github.io/ecma262/#sec-ordinarycreatefromconstructor">OrdinaryCreateFromConstructor</a></emu-xref>(NewTarget, <code>"%DisplayNamesPrototype%"</code>, « [[InitializedDisplayNames]], [[Locale]], [[Style]], [[Type]], [[Fallback]], <ins>[[DialectHandling]], </ins>[[Fields]] »).</li><li>Let <var>requestedLocales</var> be ?&nbsp;<emu-xref aoid="CanonicalizeLocaleList"><a href="https://tc39.es/ecma402/#sec-canonicalizelocalelist">CanonicalizeLocaleList</a></emu-xref>(<var>locales</var>).</li><li>Let <var>options</var> be ?&nbsp;<emu-xref aoid="ToObject" id="_ref_10"><a href="https://tc39.github.io/ecma262/#sec-toobject">ToObject</a></emu-xref>(<var>options</var>).</li><li>Let <var>opt</var> be a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>.</li><li>Let <var>localeData</var> be %DisplayNames%.[[LocaleData]].</li><li>Let <var>matcher</var> be ?&nbsp;<emu-xref aoid="GetOption"><a href="https://tc39.es/ecma402/#sec-getoption">GetOption</a></emu-xref>(<var>options</var>, <code>"localeMatcher"</code>, <code>"string"</code>, « <code>"lookup"</code>, <code>"best fit"</code> », <code>"best fit"</code>).</li><li>Set <var>opt</var>.[[localeMatcher]] to <var>matcher</var>.</li><li>Let <var>r</var> be <emu-xref aoid="ResolveLocale"><a href="https://tc39.es/ecma402/#sec-resolvelocale">ResolveLocale</a></emu-xref>(%DisplayNames%.[[AvailableLocales]], <var>requestedLocales</var>, <var>opt</var>, %DisplayNames%.[[RelevantExtensionKeys]]).</li><li>Let <var>style</var> be ?&nbsp;<emu-xref aoid="GetOption"><a href="https://tc39.es/ecma402/#sec-getoption">GetOption</a></emu-xref>(<var>options</var>, <code>"style"</code>, <code>"string"</code>, « <code>"narrow"</code>, <code>"short"</code>, <code>"long"</code> », <code>"long"</code>).</li><li>Set <var>displayNames</var>.[[Style]] to <var>style</var>.</li><li>Let <var>type</var> be ?&nbsp;<emu-xref aoid="GetOption"><a href="https://tc39.es/ecma402/#sec-getoption">GetOption</a></emu-xref>(<var>options</var>, <code>"type"</code>, <code>"string"</code>, « <code>"language"</code>, <code>"region"</code>, <code>"script"</code>, <code>"currency"</code> <ins>, <code>"calendar"</code>, <code>"dateTimeField"</code>, <code>"unit"</code></ins>», <emu-val>undefined</emu-val>).</li><li>If <var>type</var> is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Set <var>displayNames</var>.[[Type]] to <var>type</var>.</li><li>Let <var>fallback</var> be ?&nbsp;<emu-xref aoid="GetOption"><a href="https://tc39.es/ecma402/#sec-getoption">GetOption</a></emu-xref>(<var>options</var>, <code>"fallback"</code>, <code>"string"</code>, « <code>"code"</code>, <code>"none"</code> », <code>"code"</code>).</li><li>Set <var>displayNames</var>.[[Fallback]] to <var>fallback</var>.</li><li>Set <var>displayNames</var>.[[Locale]] to the value of <var>r</var>.[[Locale]].</li><li>Let <var>dataLocale</var> be <var>r</var>.[[dataLocale]].</li><li>Let <var>dataLocaleData</var> be <var>localeData</var>.[[&lt;<var>dataLocale</var>&gt;]].</li><li>Let <var>types</var> be <var>dataLocaleData</var>.[[types]].</li><li>Assert: <var>types</var> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots" id="_ref_1"><a href="#sec-Intl.DisplayNames-internal-slots">1.4.3</a></emu-xref>).</li><li>Let <var>typeFields</var> be <var>types</var>.[[&lt;<var>type</var>&gt;]].</li><li>Assert: <var>typeFields</var> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots" id="_ref_2"><a href="#sec-Intl.DisplayNames-internal-slots">1.4.3</a></emu-xref>).</li><li><ins>If <var>type</var> is <code>"language"</code>, then</ins><ol><li><ins>Let <var>dialectHandling</var> be ?&nbsp;<emu-xref aoid="GetOption"><a href="https://tc39.es/ecma402/#sec-getoption">GetOption</a></emu-xref>(<var>options</var>, <code>"dialectHandling"</code>, <code>"string"</code>, « <code>"dialect"</code>, <code>"standard"</code> », <code>"dialect"</code>).</ins></li><li><ins>Set <var>displayNames</var>.[[DialectHandling]] to <var>dialectHandling</var>.</ins></li><li><ins>Let <var>typeFields</var> be <var>typeFields</var>.[[&lt;<var>dialectHandling</var>&gt;]].</ins></li><li><ins>Assert: <var>typeFields</var> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots" id="_ref_3"><a href="#sec-Intl.DisplayNames-internal-slots">1.4.3</a></emu-xref>).</ins></li></ol></li><li>Let <var>styleFields</var> be <var>typeFields</var>.[[&lt;<var>style</var>&gt;]].</li><li>Assert: <var>styleFields</var> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots" id="_ref_4"><a href="#sec-Intl.DisplayNames-internal-slots">1.4.3</a></emu-xref>).</li><li>Set <var>displayNames</var>.[[Fields]] to <var>styleFields</var>.</li><li>Return <var>displayNames</var>.
-      </li></ol></emu-alg>
+      <emu-alg><ol><li>If NewTarget is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>displayNames</var> be ?&nbsp;<emu-xref aoid="OrdinaryCreateFromConstructor" id="_ref_9"><a href="https://tc39.es/ecma262/#sec-ordinarycreatefromconstructor">OrdinaryCreateFromConstructor</a></emu-xref>(NewTarget, <code>"%DisplayNamesPrototype%"</code>, « [[InitializedDisplayNames]], [[Locale]], [[Style]], [[Type]], [[Fallback]], <ins>[[DialectHandling]], </ins>[[Fields]] »).</li><li>Let <var>requestedLocales</var> be ?&nbsp;<emu-xref aoid="CanonicalizeLocaleList"><a href="https://tc39.es/ecma402/#sec-canonicalizelocalelist">CanonicalizeLocaleList</a></emu-xref>(<var>locales</var>).</li><li>Let <var>options</var> be ?&nbsp;<emu-xref aoid="ToObject" id="_ref_10"><a href="https://tc39.es/ecma262/#sec-toobject">ToObject</a></emu-xref>(<var>options</var>).</li><li>Let <var>opt</var> be a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>.</li><li>Let <var>localeData</var> be %DisplayNames%.[[LocaleData]].</li><li>Let <var>matcher</var> be ?&nbsp;<emu-xref aoid="GetOption"><a href="https://tc39.es/ecma402/#sec-getoption">GetOption</a></emu-xref>(<var>options</var>, <code>"localeMatcher"</code>, <code>"string"</code>, « <code>"lookup"</code>, <code>"best fit"</code> », <code>"best fit"</code>).</li><li>Set <var>opt</var>.[[localeMatcher]] to <var>matcher</var>.</li><li>Let <var>r</var> be <emu-xref aoid="ResolveLocale"><a href="https://tc39.es/ecma402/#sec-resolvelocale">ResolveLocale</a></emu-xref>(%DisplayNames%.[[AvailableLocales]], <var>requestedLocales</var>, <var>opt</var>, %DisplayNames%.[[RelevantExtensionKeys]]).</li><li>Let <var>style</var> be ?&nbsp;<emu-xref aoid="GetOption"><a href="https://tc39.es/ecma402/#sec-getoption">GetOption</a></emu-xref>(<var>options</var>, <code>"style"</code>, <code>"string"</code>, « <code>"narrow"</code>, <code>"short"</code>, <code>"long"</code> », <code>"long"</code>).</li><li>Set <var>displayNames</var>.[[Style]] to <var>style</var>.</li><li>Let <var>type</var> be ?&nbsp;<emu-xref aoid="GetOption"><a href="https://tc39.es/ecma402/#sec-getoption">GetOption</a></emu-xref>(<var>options</var>, <code>"type"</code>, <code>"string"</code>, « <code>"language"</code>, <code>"region"</code>, <code>"script"</code>, <code>"currency"</code> <ins>, <code>"calendar"</code>, <code>"dateTimeField"</code>, <code>"unit"</code></ins>», <emu-val>undefined</emu-val>).</li><li>If <var>type</var> is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Set <var>displayNames</var>.[[Type]] to <var>type</var>.</li><li>Let <var>fallback</var> be ?&nbsp;<emu-xref aoid="GetOption"><a href="https://tc39.es/ecma402/#sec-getoption">GetOption</a></emu-xref>(<var>options</var>, <code>"fallback"</code>, <code>"string"</code>, « <code>"code"</code>, <code>"none"</code> », <code>"code"</code>).</li><li>Set <var>displayNames</var>.[[Fallback]] to <var>fallback</var>.</li><li>Set <var>displayNames</var>.[[Locale]] to the value of <var>r</var>.[[Locale]].</li><li>Let <var>dataLocale</var> be <var>r</var>.[[dataLocale]].</li><li>Let <var>dataLocaleData</var> be <var>localeData</var>.[[&lt;<var>dataLocale</var>&gt;]].</li><li>Let <var>types</var> be <var>dataLocaleData</var>.[[types]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>types</var> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots" id="_ref_1"><a href="#sec-Intl.DisplayNames-internal-slots">1.4.3</a></emu-xref>).</li><li>Let <var>typeFields</var> be <var>types</var>.[[&lt;<var>type</var>&gt;]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>typeFields</var> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots" id="_ref_2"><a href="#sec-Intl.DisplayNames-internal-slots">1.4.3</a></emu-xref>).</li><li><ins>If <var>type</var> is <code>"language"</code>, then</ins><ol><li><ins>Let <var>dialectHandling</var> be ?&nbsp;<emu-xref aoid="GetOption"><a href="https://tc39.es/ecma402/#sec-getoption">GetOption</a></emu-xref>(<var>options</var>, <code>"dialectHandling"</code>, <code>"string"</code>, « <code>"dialect"</code>, <code>"standard"</code> », <code>"dialect"</code>).</ins></li><li><ins>Set <var>displayNames</var>.[[DialectHandling]] to <var>dialectHandling</var>.</ins></li><li><ins>Let <var>typeFields</var> be <var>typeFields</var>.[[&lt;<var>dialectHandling</var>&gt;]].</ins></li><li><ins><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>typeFields</var> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots" id="_ref_3"><a href="#sec-Intl.DisplayNames-internal-slots">1.4.3</a></emu-xref>).</ins></li></ol></li><li>Let <var>styleFields</var> be <var>typeFields</var>.[[&lt;<var>style</var>&gt;]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>styleFields</var> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots" id="_ref_4"><a href="#sec-Intl.DisplayNames-internal-slots">1.4.3</a></emu-xref>).</li><li>Set <var>displayNames</var>.[[Fields]] to <var>styleFields</var>.</li><li>Return <var>displayNames</var>.</li></ol></emu-alg>
     </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-properties-of-intl-displaynames-constructor">
-    <h1><span class="secnum">1.4</span>Properties of the Intl.DisplayNames Constructor</h1>
+    <h1><span class="secnum">1.4</span> Properties of the Intl.DisplayNames Constructor</h1>
 
     <p>
-      The Intl.DisplayNames constructor has the following properties:
-    
+      The Intl.DisplayNames <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> has the following properties:
     </p>
 
     <emu-clause id="sec-Intl.DisplayNames.prototype">
-      <h1><span class="secnum">1.4.1</span>Intl.DisplayNames.prototype</h1>
+      <h1><span class="secnum">1.4.1</span> Intl.DisplayNames.prototype</h1>
 
       <p>
         The value of <emu-val>Intl.DisplayNames.prototype</emu-val> is <emu-val>%DisplayNamesPrototype%</emu-val>.
-      
       </p>
       <p>
         This property has the attributes { [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }.
-      
       </p>
     </emu-clause>
 
     <emu-clause id="sec-Intl.DisplayNames.supportedLocalesOf">
-      <h1><span class="secnum">1.4.2</span>Intl.DisplayNames.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )</h1>
+      <h1><span class="secnum">1.4.2</span> Intl.DisplayNames.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )</h1>
 
       <p>
         When the <emu-val>supportedLocalesOf</emu-val> method of <emu-val>%DisplayNames%</emu-val> is called, the following steps are taken:
-      
       </p>
 
-      <emu-alg><ol><li>Let <var>availableLocales</var> be <emu-val>%DisplayNames%</emu-val>.[[AvailableLocales]].</li><li>Let <var>requestedLocales</var> be ?&nbsp;<emu-xref aoid="CanonicalizeLocaleList"><a href="https://tc39.es/ecma402/#sec-canonicalizelocalelist">CanonicalizeLocaleList</a></emu-xref>(<var>locales</var>).</li><li>Return ?&nbsp;<emu-xref aoid="SupportedLocales"><a href="https://tc39.es/ecma402/#sec-supportedlocales">SupportedLocales</a></emu-xref>(<var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var>).
-      </li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>availableLocales</var> be <emu-val>%DisplayNames%</emu-val>.[[AvailableLocales]].</li><li>Let <var>requestedLocales</var> be ?&nbsp;<emu-xref aoid="CanonicalizeLocaleList"><a href="https://tc39.es/ecma402/#sec-canonicalizelocalelist">CanonicalizeLocaleList</a></emu-xref>(<var>locales</var>).</li><li>Return ?&nbsp;<emu-xref aoid="SupportedLocales"><a href="https://tc39.es/ecma402/#sec-supportedlocales">SupportedLocales</a></emu-xref>(<var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var>).</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-Intl.DisplayNames-internal-slots">
-      <h1><span class="secnum">1.4.3</span>Internal slots</h1>
+      <h1><span class="secnum">1.4.3</span> Internal slots</h1>
 
       <p>
-        The value of the [[AvailableLocales]] internal slot is implementation defined within the constraints described in  <emu-xref href="#sec-internal-slots"><a href="https://tc39.es/ecma402/#sec-internal-slots">9.1</a></emu-xref>.
-      
+        The value of the [[AvailableLocales]] internal slot is implementation defined within the constraints described in <emu-xref href="#sec-internal-slots"><a href="https://tc39.es/ecma402/#sec-internal-slots">9.1</a></emu-xref>.
       </p>
 
       <p>
         The value of the [[RelevantExtensionKeys]] internal slot is « ».
-      
       </p>
 
       <p>
-        The value of the [[LocaleData]] internal slot is implementation defined within the constraints described in  <emu-xref href="#sec-internal-slots"><a href="https://tc39.es/ecma402/#sec-internal-slots">9.1</a></emu-xref> and the following additional constraints:
-      
+        The value of the [[LocaleData]] internal slot is implementation defined within the constraints described in <emu-xref href="#sec-internal-slots"><a href="https://tc39.es/ecma402/#sec-internal-slots">9.1</a></emu-xref> and the following additional constraints:
       </p>
 
       <ul>
-        <li>[[LocaleData]].[[&lt;<var>locale</var>&gt;]] must have a [[types]] field for all locale values <var>locale</var>. The value of this field must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>, which must have fields with the names of one of the valid display name types: <code>"language"</code>, <code>"region"</code>, <code>"script"</code>,  <del>and</del> <code>"currency"</code><ins>, <code>"calendar"</code>, <code>"dateTimeField"</code>, and <code>"unit"</code></ins>.</li>
-        <li><ins>The value of the field <code>"language"</code> must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> which must have fields with the names of one of the valid display name dialect handlings: <code>"dialect"</code>, and <code>"standard"</code>.</ins></li>
+        <li>[[LocaleData]].[[&lt;<var>locale</var>&gt;]] must have a [[types]] field for all locale values <var>locale</var>. The value of this field must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>, which must have fields with the names of one of the valid display name types: <code>"language"</code>, <code>"region"</code>, <code>"script"</code>, <del>and</del> <code>"currency"</code><ins>, <code>"calendar"</code>, <code>"dateTimeField"</code>, and <code>"unit"</code></ins>.</li>
+        <li><ins>The value of the field <code>"language"</code> must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> which must have fields with the names of one of the valid display name dialect handlings: <code>"dialect"</code>, and <code>"standard"</code>.</ins></li>
         <li><ins>The display name dialect handling fields under display name type <code>"language"</code> should contain Records which must have fields with the names of one of the valid display name styles: <code>"narrow"</code>, <code>"short"</code>, and <code>"long"</code>.</ins></li>
-        <li>The value of fields  <del><code>"language"</code>,  </del><code>"region"</code>, <code>"script"</code>,  <del>and  </del><code>"currency"</code><ins>, <code>"calendar"</code>, <code>"dateTimeField"</code>, and <code>"unit"</code></ins> must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> which must have fields with the names of one of the valid display name styles: <code>"narrow"</code>, <code>"short"</code>, and <code>"long"</code>.</li>
+        <li>The value of fields <del><code>"language"</code>, </del><code>"region"</code>, <code>"script"</code>, <del>and </del><code>"currency"</code><ins>, <code>"calendar"</code>, <code>"dateTimeField"</code>, and <code>"unit"</code></ins> must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> which must have fields with the names of one of the valid display name styles: <code>"narrow"</code>, <code>"short"</code>, and <code>"long"</code>.</li>
         <li>The display name styles fields under display name type <code>"language"</code> should contain Records, with keys corresponding to language codes according to <code>unicode_language_id</code> production. The value of these fields must be string values.</li>
         <li>The display name styles fields under display name type <code>"region"</code> should contain Records, with keys corresponding to region codes. The value of these fields must be string values.</li>
         <li>The display name styles fields under display name type <code>"script"</code> should contain Records, with keys corresponding to script codes. The value of these fields must be string values.</li>
         <li>The display name styles fields under display name type <code>"currency"</code> should contain Records, with keys corresponding to currency codes. The value of these fields must be string values.</li>
         <li><ins>The display name styles fields under display name type <code>"calendar"</code> should contain Records, with keys corresponding to a String value with the "type" given in Unicode Technical Standard 35 for the calendar used for formatting. The value of these fields must be string values.</ins></li>
-        <li><ins>The display name styles fields under display name type <code>"dateTimeField"</code> should contain Records, with keys corresponding to codes listed in  <emu-xref href="#table-validcodefordatetimefield" id="_ref_5"><a href="#table-validcodefordatetimefield">Table 1</a></emu-xref>. The value of these fields must be string values.</ins></li>
+        <li><ins>The display name styles fields under display name type <code>"dateTimeField"</code> should contain Records, with keys corresponding to codes listed in <emu-xref href="#table-validcodefordatetimefield" id="_ref_5"><a href="#table-validcodefordatetimefield">Table 1</a></emu-xref>. The value of these fields must be string values.</ins></li>
         <li><ins>The display name styles fields under display name type <code>"unit"</code> should contain Records, with keys corresponding to a well-formed core unit identifier as defined in UTS #35, Part 2, Section 6.. The value of these fields must be string values.</ins></li>
       </ul>
 
       <emu-note><span class="note">Note</span><div class="note-contents">
-        It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at  <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>).
-      
+        It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>).
       </div></emu-note>
     </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-properties-of-intl-displaynames-prototype-object">
-    <h1><span class="secnum">1.5</span>Properties of the Intl.DisplayNames Prototype Object</h1>
+    <h1><span class="secnum">1.5</span> Properties of the Intl.DisplayNames Prototype Object</h1>
 
     <p>
       The Intl.DisplayNames prototype object, referred to as <emu-val>%DisplayNamesPrototype%</emu-val>, is itself an ordinary object. It is not a Intl.DisplayNames instance, does not have an [[InitializedDisplayNames]] internal slot or any of the other internal slots of Intl.DisplayNames instance objects.
-    
     </p>
 
     <emu-clause id="sec-Intl.DisplayNames.prototype.constructor">
-      <h1><span class="secnum">1.5.1</span>Intl.DisplayNames.prototype.constructor</h1>
+      <h1><span class="secnum">1.5.1</span> Intl.DisplayNames.prototype.constructor</h1>
 
       <p>
         The initial value of <emu-val>Intl.DisplayNames.prototype.constructor</emu-val> is the intrinsic object <emu-val>%DisplayNames%</emu-val>.
-      
       </p>
     </emu-clause>
 
     <emu-clause id="sec-Intl.DisplayNames.prototype-@@tostringtag">
-      <h1><span class="secnum">1.5.2</span>Intl.DisplayNames.prototype[ @@toStringTag ]</h1>
+      <h1><span class="secnum">1.5.2</span> Intl.DisplayNames.prototype[ @@toStringTag ]</h1>
 
       <p>
         The initial value of the @@toStringTag property is the string value <code>"Intl.DisplayNames"</code>.
-      
       </p>
       <p>
         This property has the attributes { [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }.
-      
       </p>
     </emu-clause>
 
     <emu-clause id="sec-Intl.DisplayNames.prototype.of" aoid="Intl.DisplayNames.prototype.of">
-      <h1><span class="secnum">1.5.3</span>Intl.DisplayNames.prototype.of ( <var>code</var> )</h1>
+      <h1><span class="secnum">1.5.3</span> Intl.DisplayNames.prototype.of ( <var>code</var> )</h1>
 
       <p>
         When the <emu-val>Intl.DisplayNames.prototype.of</emu-val> is called with an argument <var>code</var>, the following steps are taken:
-      
       </p>
 
-      <emu-alg><ol><li>Let <var>displayNames</var> be <emu-val>this</emu-val> value.</li><li>If <emu-xref aoid="Type" id="_ref_11"><a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>displayNames</var>) is not Object, throw a <emu-val>TypeError</emu-val> exception.</li><li>If <var>displayNames</var> does not have an [[InitializedDisplayNames]] internal slot, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>code</var> be ?&nbsp;<emu-xref aoid="ToString" id="_ref_12"><a href="https://tc39.github.io/ecma262/#sec-tostring">ToString</a></emu-xref>(<var>code</var>).</li><li>Let <var>code</var> be ?&nbsp;<emu-xref aoid="CanonicalCodeForDisplayNames" id="_ref_13"><a href="#sec-canonicalcodefordisplaynames">CanonicalCodeForDisplayNames</a></emu-xref>(<var>displayNames</var>.[[Type]], <var>code</var>).</li><li>Let <var>fields</var> be <var>displayNames</var>.[[Fields]].</li><li>Let <var>name</var> be <var>fields</var>[[&lt;<var>code</var>&gt;]].</li><li>If <var>name</var> is not <emu-val>undefined</emu-val>, return <var>name</var>.</li><li>If <var>displayNames</var>.[[Fallback]] is <code>"code"</code>, return <var>code</var>.</li><li>Return <emu-val>undefined</emu-val>.
-      </li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>displayNames</var> be <emu-val>this</emu-val> value.</li><li>If <emu-xref aoid="Type" id="_ref_11"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>displayNames</var>) is not Object, throw a <emu-val>TypeError</emu-val> exception.</li><li>If <var>displayNames</var> does not have an [[InitializedDisplayNames]] internal slot, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>code</var> be ?&nbsp;<emu-xref aoid="ToString" id="_ref_12"><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></emu-xref>(<var>code</var>).</li><li>Let <var>code</var> be ?&nbsp;<emu-xref aoid="CanonicalCodeForDisplayNames" id="_ref_13"><a href="#sec-canonicalcodefordisplaynames">CanonicalCodeForDisplayNames</a></emu-xref>(<var>displayNames</var>.[[Type]], <var>code</var>).</li><li>Let <var>fields</var> be <var>displayNames</var>.[[Fields]].</li><li>Let <var>name</var> be <var>fields</var>[[&lt;<var>code</var>&gt;]].</li><li>If <var>name</var> is not <emu-val>undefined</emu-val>, return <var>name</var>.</li><li>If <var>displayNames</var>.[[Fallback]] is <code>"code"</code>, return <var>code</var>.</li><li>Return <emu-val>undefined</emu-val>.</li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-Intl.DisplayNames.prototype.resolvedOptions">
-      <h1><span class="secnum">1.5.4</span>Intl.DisplayNames.prototype.resolvedOptions ( )</h1>
+      <h1><span class="secnum">1.5.4</span> Intl.DisplayNames.prototype.resolvedOptions ( )</h1>
 
       <p>
         This function provides access to the locale and options computed during initialization of the object.
-      
       </p>
 
-      <emu-alg><ol><li>Let <var>displayNames</var> be <emu-val>this</emu-val> value.</li><li>If <emu-xref aoid="Type" id="_ref_14"><a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>displayNames</var>) is not Object, throw a <emu-val>TypeError</emu-val> exception.</li><li>If <var>displayNames</var> does not have an [[InitializedDisplayNames]] internal slot, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>options</var> be !&nbsp;<emu-xref aoid="ObjectCreate" id="_ref_15"><a href="https://tc39.github.io/ecma262/#sec-objectcreate">ObjectCreate</a></emu-xref>(<emu-xref href="#sec-properties-of-the-object-prototype-object"><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a></emu-xref>).</li><li>For each row of <emu-xref href="#table-displaynames-resolvedoptions-properties" id="_ref_6"><a href="#table-displaynames-resolvedoptions-properties">Table 2</a></emu-xref>, except the header row, in table order, do<ol><li>Let <var>p</var> be the Property value of the current row.</li><li>Let <var>v</var> be the value of <var>displayNames</var>'s internal slot whose name is the Internal Slot value of the current row.</li><li>If <var>v</var> is not <emu-val>undefined</emu-val>, then<ol><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_16"><a href="https://tc39.github.io/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>options</var>, <var>p</var>, <var>v</var>).</li></ol></li></ol></li><li>Return <var>options</var>.
-      </li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>displayNames</var> be <emu-val>this</emu-val> value.</li><li>If <emu-xref aoid="Type" id="_ref_14"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>displayNames</var>) is not Object, throw a <emu-val>TypeError</emu-val> exception.</li><li>If <var>displayNames</var> does not have an [[InitializedDisplayNames]] internal slot, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>options</var> be !&nbsp;<emu-xref aoid="ObjectCreate" id="_ref_15"><a href="https://tc39.es/ecma262/#sec-objectcreate">ObjectCreate</a></emu-xref>(<emu-xref href="#sec-properties-of-the-object-prototype-object"><a href="https://tc39.es/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a></emu-xref>).</li><li>For each row of <emu-xref href="#table-displaynames-resolvedoptions-properties" id="_ref_6"><a href="#table-displaynames-resolvedoptions-properties">Table 2</a></emu-xref>, except the header row, in table order, do<ol><li>Let <var>p</var> be the Property value of the current row.</li><li>Let <var>v</var> be the value of <var>displayNames</var>'s internal slot whose name is the Internal Slot value of the current row.</li><li>If <var>v</var> is not <emu-val>undefined</emu-val>, then<ol><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_16"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>options</var>, <var>p</var>, <var>v</var>).</li></ol></li></ol></li><li>Return <var>options</var>.</li></ol></emu-alg>
 
       <emu-table id="table-displaynames-resolvedoptions-properties"><figure><figcaption>Table 2: Resolved Options of DisplayNames Instances</figcaption>
         
@@ -2085,35 +2107,32 @@ li.menu-search-result-term:before {
   </emu-clause>
 
   <emu-clause id="sec-properties-of-intl-displaynames-instances">
-    <h1><span class="secnum">1.6</span>Properties of Intl.DisplayNames Instances</h1>
+    <h1><span class="secnum">1.6</span> Properties of Intl.DisplayNames Instances</h1>
 
     <p>
       Intl.DisplayNames instances are ordinary objects that inherit properties from %DisplayNamesPrototype%.
-    
     </p>
 
     <p>
       Intl.DisplayNames instances have an [[InitializedDisplayNames]] internal slot.
-    
     </p>
 
     <p>
-      Intl.DisplayNames instances also have several internal slots that are computed by the constructor:
-    
+      Intl.DisplayNames instances also have several internal slots that are computed by the <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref>:
     </p>
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
       <li>[[Style]] is one of the String values <code>"narrow"</code>, <code>"short"</code>, or <code>"long"</code>, identifying the display names style used.</li>
-      <li>[[Type]] is one of the String values <code>"language"</code>, <code>"region"</code>, <code>"script"</code>,  <del>or  </del><code>"currency"</code>,<ins> <code>"calendar"</code>, <code>"dateTimeField"</code>, or <code>"unit"</code>,</ins> identifying the type of the display names requested.</li>
+      <li>[[Type]] is one of the String values <code>"language"</code>, <code>"region"</code>, <code>"script"</code>, <del>or </del><code>"currency"</code>,<ins> <code>"calendar"</code>, <code>"dateTimeField"</code>, or <code>"unit"</code>,</ins> identifying the type of the display names requested.</li>
       <li>[[Fallback]] is one of the String values <code>"code"</code>, or <code>"none"</code>, identifying the fallback return when the system does not have the requested display name.</li>
       <li><ins>[[DialectHandling]] is one of the String values <code>"dialect"</code>, or <code>"standard"</code>, identifying the display names dialect handling while and only while the [[Type]] is <code>"language"</code>.</ins></li>
-      <li>[[Fields]] is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see  <emu-xref href="#sec-Intl.DisplayNames-internal-slots" id="_ref_7"><a href="#sec-Intl.DisplayNames-internal-slots">1.4.3</a></emu-xref>) which
-        must have fields with keys corresponding to codes according to [[Style]]  <del>and</del><ins>,</ins> [[Type]]<ins>, and [[DialectHandling]]</ins>.</li>
+      <li>[[Fields]] is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots" id="_ref_7"><a href="#sec-Intl.DisplayNames-internal-slots">1.4.3</a></emu-xref>) which
+        must have fields with keys corresponding to codes according to [[Style]] <del>and</del><ins>,</ins> [[Type]]<ins>, and [[DialectHandling]]</ins>.</li>
     </ul>
   </emu-clause>
 </emu-clause><emu-annex id="sec-copyright-and-software-license">
-      <h1><span class="secnum">A</span>Copyright &amp; Software License</h1>
+      <h1><span class="secnum">A</span> Copyright &amp; Software License</h1>
       
       <h2>Copyright Notice</h2>
       <p>© 2021 Google, Ecma International</p>
@@ -2131,6 +2150,5 @@ li.menu-search-result-term:before {
 
 <p>THIS SOFTWARE IS PROVIDED BY THE ECMA INTERNATIONAL "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ECMA INTERNATIONAL BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
 
-    </emu-annex>
-</emu-import>
+    </emu-annex></emu-import>
 </div></body>

--- a/index.html
+++ b/index.html
@@ -3,25 +3,20 @@
 <link rel="stylesheet" href="./spec.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
 <script src="./spec.js"></script>
-<title>Intl.DisplayNames v2 Proposal</title><script type="application/json" id="menu-search-biblio">[{"type":"clause","id":"sec-intro","aoid":null,"title":"Introduction","titleHTML":"Introduction","number":"","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Introduction"},{"type":"op","aoid":"CanonicalCodeForDisplayNames","refId":"sec-canonicalcodefordisplaynames","location":"","referencingIds":[],"key":"CanonicalCodeForDisplayNames"},{"type":"clause","id":"sec-canonicalcodefordisplaynames","aoid":"CanonicalCodeForDisplayNames","title":"CanonicalCodeForDisplayNames ( type, code)","titleHTML":"CanonicalCodeForDisplayNames ( <var>type</var>, <var>code</var>)","number":"1.1.1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":["_ref_13"],"key":"CanonicalCodeForDisplayNames ( type, code)"},{"type":"clause","id":"sec-intl-displaynames-abstracts","aoid":null,"title":"Abstract Operations for DisplayNames Objects","titleHTML":"Abstract Operations for DisplayNames Objects","number":"1.1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Abstract Operations for DisplayNames Objects"},{"type":"table","id":"table-validcodefordatetimefield","node":{},"number":1,"caption":"Table 1: <ins>Codes For Date Time Field of DisplayNames</ins>","referencingIds":["_ref_0","_ref_5"],"namespace":"https://tc39.es/intl-displaynames-v2/","location":"","key":"Table 1: <ins>Codes For Date Time Field of DisplayNames</ins>"},{"type":"op","aoid":"IsValidDateTimeFieldCode","refId":"sec-isvaliddatetimefieldcode","location":"","referencingIds":[],"key":"IsValidDateTimeFieldCode"},{"type":"clause","id":"sec-isvaliddatetimefieldcode","aoid":"IsValidDateTimeFieldCode","title":"IsValidDateTimeFieldCode ( field )","titleHTML":"<ins>IsValidDateTimeFieldCode ( <var>field</var> )</ins>","number":"1.2","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":["_ref_8"],"key":"IsValidDateTimeFieldCode ( field )"},{"type":"clause","id":"sec-Intl.DisplayNames","aoid":null,"title":"Intl.DisplayNames ( locales, options )","titleHTML":"Intl.DisplayNames ( <var>locales</var>, <var>options</var> )","number":"1.3.1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames ( locales, options )"},{"type":"clause","id":"sec-intl-displaynames-constructor","aoid":null,"title":"The Intl.DisplayNames Constructor","titleHTML":"The Intl.DisplayNames Constructor","number":"1.3","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"The Intl.DisplayNames Constructor"},{"type":"clause","id":"sec-Intl.DisplayNames.prototype","aoid":null,"title":"Intl.DisplayNames.prototype","titleHTML":"Intl.DisplayNames.prototype","number":"1.4.1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype"},{"type":"clause","id":"sec-Intl.DisplayNames.supportedLocalesOf","aoid":null,"title":"Intl.DisplayNames.supportedLocalesOf ( locales [ , options ] )","titleHTML":"Intl.DisplayNames.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )","number":"1.4.2","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.supportedLocalesOf ( locales [ , options ] )"},{"type":"clause","id":"sec-Intl.DisplayNames-internal-slots","aoid":null,"title":"Internal slots","titleHTML":"Internal slots","number":"1.4.3","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":["_ref_1","_ref_2","_ref_3","_ref_4","_ref_7"],"key":"Internal slots"},{"type":"clause","id":"sec-properties-of-intl-displaynames-constructor","aoid":null,"title":"Properties of the Intl.DisplayNames Constructor","titleHTML":"Properties of the Intl.DisplayNames Constructor","number":"1.4","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Properties of the Intl.DisplayNames Constructor"},{"type":"clause","id":"sec-Intl.DisplayNames.prototype.constructor","aoid":null,"title":"Intl.DisplayNames.prototype.constructor","titleHTML":"Intl.DisplayNames.prototype.constructor","number":"1.5.1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype.constructor"},{"type":"clause","id":"sec-Intl.DisplayNames.prototype-@@tostringtag","aoid":null,"title":"Intl.DisplayNames.prototype[ @@toStringTag ]","titleHTML":"Intl.DisplayNames.prototype[ @@toStringTag ]","number":"1.5.2","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype[ @@toStringTag ]"},{"type":"op","aoid":"Intl.DisplayNames.prototype.of","refId":"sec-Intl.DisplayNames.prototype.of","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype.of"},{"type":"clause","id":"sec-Intl.DisplayNames.prototype.of","aoid":"Intl.DisplayNames.prototype.of","title":"Intl.DisplayNames.prototype.of ( code )","titleHTML":"Intl.DisplayNames.prototype.of ( <var>code</var> )","number":"1.5.3","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype.of ( code )"},{"type":"table","id":"table-displaynames-resolvedoptions-properties","node":{},"number":2,"caption":"Table 2: Resolved Options of DisplayNames Instances","referencingIds":["_ref_6"],"namespace":"https://tc39.es/intl-displaynames-v2/","location":"","key":"Table 2: Resolved Options of DisplayNames Instances"},{"type":"clause","id":"sec-Intl.DisplayNames.prototype.resolvedOptions","aoid":null,"title":"Intl.DisplayNames.prototype.resolvedOptions ( )","titleHTML":"Intl.DisplayNames.prototype.resolvedOptions ( )","number":"1.5.4","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype.resolvedOptions ( )"},{"type":"clause","id":"sec-properties-of-intl-displaynames-prototype-object","aoid":null,"title":"Properties of the Intl.DisplayNames Prototype Object","titleHTML":"Properties of the Intl.DisplayNames Prototype Object","number":"1.5","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Properties of the Intl.DisplayNames Prototype Object"},{"type":"clause","id":"sec-properties-of-intl-displaynames-instances","aoid":null,"title":"Properties of Intl.DisplayNames Instances","titleHTML":"Properties of Intl.DisplayNames Instances","number":"1.6","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Properties of Intl.DisplayNames Instances"},{"type":"clause","id":"intl-displaynames-objects","aoid":null,"title":"DisplayNames Objects","titleHTML":"DisplayNames Objects","number":"1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"DisplayNames Objects"},{"type":"clause","id":"sec-copyright-and-software-license","aoid":null,"title":"Copyright & Software License","titleHTML":"Copyright &amp; Software License","number":"A","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Copyright & Software License"}]</script><script>"use strict";
+<title>Intl.DisplayNames v2 Proposal</title><script type="application/json" id="menu-search-biblio">[{"type":"clause","id":"sec-intro","aoid":null,"title":"Introduction","titleHTML":"Introduction","number":"","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Introduction"},{"type":"op","aoid":"CanonicalCodeForDisplayNames","refId":"sec-canonicalcodefordisplaynames","location":"","referencingIds":[],"key":"CanonicalCodeForDisplayNames"},{"type":"clause","id":"sec-canonicalcodefordisplaynames","aoid":"CanonicalCodeForDisplayNames","title":"CanonicalCodeForDisplayNames ( type, code)","titleHTML":"CanonicalCodeForDisplayNames ( <var>type</var>, <var>code</var>)","number":"1.1.1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":["_ref_13"],"key":"CanonicalCodeForDisplayNames ( type, code)"},{"type":"clause","id":"sec-intl-displaynames-abstracts","aoid":null,"title":"Abstract Operations for DisplayNames Objects","titleHTML":"Abstract Operations for DisplayNames Objects","number":"1.1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Abstract Operations for DisplayNames Objects"},{"type":"table","id":"table-validcodefordatetimefield","number":1,"caption":"Table 1: <ins>Codes For Date Time Field of DisplayNames</ins>","referencingIds":["_ref_0","_ref_5"],"namespace":"https://tc39.es/intl-displaynames-v2/","location":"","key":"Table 1: <ins>Codes For Date Time Field of DisplayNames</ins>"},{"type":"op","aoid":"IsValidDateTimeFieldCode","refId":"sec-isvaliddatetimefieldcode","location":"","referencingIds":[],"key":"IsValidDateTimeFieldCode"},{"type":"clause","id":"sec-isvaliddatetimefieldcode","aoid":"IsValidDateTimeFieldCode","title":"IsValidDateTimeFieldCode ( field )","titleHTML":"<ins>IsValidDateTimeFieldCode ( <var>field</var> )</ins>","number":"1.2","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":["_ref_8"],"key":"IsValidDateTimeFieldCode ( field )"},{"type":"clause","id":"sec-Intl.DisplayNames","aoid":null,"title":"Intl.DisplayNames ( locales, options )","titleHTML":"Intl.DisplayNames ( <var>locales</var>, <var>options</var> )","number":"1.3.1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames ( locales, options )"},{"type":"clause","id":"sec-intl-displaynames-constructor","aoid":null,"title":"The Intl.DisplayNames Constructor","titleHTML":"The Intl.DisplayNames Constructor","number":"1.3","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"The Intl.DisplayNames Constructor"},{"type":"clause","id":"sec-Intl.DisplayNames.prototype","aoid":null,"title":"Intl.DisplayNames.prototype","titleHTML":"Intl.DisplayNames.prototype","number":"1.4.1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype"},{"type":"clause","id":"sec-Intl.DisplayNames.supportedLocalesOf","aoid":null,"title":"Intl.DisplayNames.supportedLocalesOf ( locales [ , options ] )","titleHTML":"Intl.DisplayNames.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )","number":"1.4.2","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.supportedLocalesOf ( locales [ , options ] )"},{"type":"clause","id":"sec-Intl.DisplayNames-internal-slots","aoid":null,"title":"Internal slots","titleHTML":"Internal slots","number":"1.4.3","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":["_ref_1","_ref_2","_ref_3","_ref_4","_ref_7"],"key":"Internal slots"},{"type":"clause","id":"sec-properties-of-intl-displaynames-constructor","aoid":null,"title":"Properties of the Intl.DisplayNames Constructor","titleHTML":"Properties of the Intl.DisplayNames Constructor","number":"1.4","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Properties of the Intl.DisplayNames Constructor"},{"type":"clause","id":"sec-Intl.DisplayNames.prototype.constructor","aoid":null,"title":"Intl.DisplayNames.prototype.constructor","titleHTML":"Intl.DisplayNames.prototype.constructor","number":"1.5.1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype.constructor"},{"type":"clause","id":"sec-Intl.DisplayNames.prototype-@@tostringtag","aoid":null,"title":"Intl.DisplayNames.prototype[ @@toStringTag ]","titleHTML":"Intl.DisplayNames.prototype[ @@toStringTag ]","number":"1.5.2","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype[ @@toStringTag ]"},{"type":"op","aoid":"Intl.DisplayNames.prototype.of","refId":"sec-Intl.DisplayNames.prototype.of","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype.of"},{"type":"clause","id":"sec-Intl.DisplayNames.prototype.of","aoid":"Intl.DisplayNames.prototype.of","title":"Intl.DisplayNames.prototype.of ( code )","titleHTML":"Intl.DisplayNames.prototype.of ( <var>code</var> )","number":"1.5.3","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype.of ( code )"},{"type":"table","id":"table-displaynames-resolvedoptions-properties","number":2,"caption":"Table 2: Resolved Options of DisplayNames Instances","referencingIds":["_ref_6"],"namespace":"https://tc39.es/intl-displaynames-v2/","location":"","key":"Table 2: Resolved Options of DisplayNames Instances"},{"type":"clause","id":"sec-Intl.DisplayNames.prototype.resolvedOptions","aoid":null,"title":"Intl.DisplayNames.prototype.resolvedOptions ( )","titleHTML":"Intl.DisplayNames.prototype.resolvedOptions ( )","number":"1.5.4","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Intl.DisplayNames.prototype.resolvedOptions ( )"},{"type":"clause","id":"sec-properties-of-intl-displaynames-prototype-object","aoid":null,"title":"Properties of the Intl.DisplayNames Prototype Object","titleHTML":"Properties of the Intl.DisplayNames Prototype Object","number":"1.5","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Properties of the Intl.DisplayNames Prototype Object"},{"type":"clause","id":"sec-properties-of-intl-displaynames-instances","aoid":null,"title":"Properties of Intl.DisplayNames Instances","titleHTML":"Properties of Intl.DisplayNames Instances","number":"1.6","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Properties of Intl.DisplayNames Instances"},{"type":"clause","id":"intl-displaynames-objects","aoid":null,"title":"DisplayNames Objects","titleHTML":"DisplayNames Objects","number":"1","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"DisplayNames Objects"},{"type":"clause","id":"sec-copyright-and-software-license","aoid":null,"title":"Copyright & Software License","titleHTML":"Copyright &amp; Software License","number":"A","namespace":"https://tc39.es/intl-displaynames-v2/","location":"","referencingIds":[],"key":"Copyright & Software License"}]</script><script>"use strict";
 
 function Search(menu) {
   this.menu = menu;
   this.$search = document.getElementById('menu-search');
   this.$searchBox = document.getElementById('menu-search-box');
   this.$searchResults = document.getElementById('menu-search-results');
-
+  
   this.loadBiblio();
-
+  
   document.addEventListener('keydown', this.documentKeydown.bind(this));
-
+  
   this.$searchBox.addEventListener('keydown', debounce(this.searchBoxKeydown.bind(this), { stopPropagation: true }));
   this.$searchBox.addEventListener('keyup', debounce(this.searchBoxKeyup.bind(this), { stopPropagation: true }));
-
-  // Perform an initial search if the box is not empty.
-  if (this.$searchBox.value) {
-    this.search(this.$searchBox.value);
-  }
 }
 
 Search.prototype.loadBiblio = function () {
@@ -61,7 +56,7 @@ Search.prototype.searchBoxKeyup = function (e) {
   if (e.keyCode === 13 || e.keyCode === 9) {
     return;
   }
-
+  
   this.search(e.target.value);
 }
 
@@ -84,23 +79,25 @@ Search.prototype.triggerSearch = function (e) {
 // prefer shorter matches.
 function relevance(result, searchString) {
   var relevance = 0;
-
+  
   relevance = Math.max(0, 8 - result.match.chunks) << 7;
-
+  
   if (result.match.caseMatch) {
     relevance *= 2;
   }
-
+  
   if (result.match.prefix) {
     relevance += 2048
   }
-
+  
   relevance += Math.max(0, 255 - result.entry.key.length);
-
+  
   return relevance;
 }
 
 Search.prototype.search = function (searchString) {
+  var s = Date.now();
+
   if (searchString === '') {
     this.displayResults([]);
     this.hideSearch();
@@ -108,12 +105,12 @@ Search.prototype.search = function (searchString) {
   } else {
     this.showSearch();
   }
-
+  
   if (searchString.length === 1) {
     this.displayResults([]);
     return;
   }
-
+    
   var results;
 
   if (/^[\d\.]*$/.test(searchString)) {
@@ -124,7 +121,7 @@ Search.prototype.search = function (searchString) {
     });
   } else {
     results = [];
-
+    
     for (var i = 0; i < this.biblio.length; i++) {
       var entry = this.biblio[i];
       if (!entry.key) {
@@ -137,11 +134,11 @@ Search.prototype.search = function (searchString) {
         results.push({ entry: entry, match: match });
       }
     }
-
+  
     results.forEach(function (result) {
       result.relevance = relevance(result, searchString);
     });
-
+    
     results = results.sort(function (a, b) { return b.relevance - a.relevance });
 
   }
@@ -149,7 +146,7 @@ Search.prototype.search = function (searchString) {
   if (results.length > 50) {
     results = results.slice(0, 50);
   }
-
+  
   this.displayResults(results);
 }
 Search.prototype.hideSearch = function () {
@@ -166,7 +163,7 @@ Search.prototype.selectResult = function () {
   if ($first) {
     document.location = $first.getAttribute('href');
   }
-
+  
   this.$searchBox.value = '';
   this.$searchBox.blur();
   this.displayResults([]);
@@ -180,7 +177,7 @@ Search.prototype.selectResult = function () {
 Search.prototype.displayResults = function (results) {
   if (results.length > 0) {
     this.$searchResults.classList.remove('no-results');
-
+    
     var html = '<ul>';
 
     results.forEach(function (result) {
@@ -197,7 +194,7 @@ Search.prototype.displayResults = function (results) {
       } else if (entry.type === 'production') {
         text = entry.key;
         cssClass = 'prod';
-        id = entry.id;
+        id = entry.id;  
       } else if (entry.type === 'op') {
         text = entry.key;
         cssClass = 'op';
@@ -209,7 +206,7 @@ Search.prototype.displayResults = function (results) {
       }
 
       if (text) {
-        html += '<li class=menu-search-result-' + cssClass + '><a href="#' + id + '">' + text + '</a></li>';
+        html += '<li class=menu-search-result-' + cssClass + '><a href="#' + id + '">' + text + '</a></li>'
       }
     });
 
@@ -232,7 +229,7 @@ function Menu() {
   this.$toc = document.querySelector('#menu-toc > ol');
   this.$specContainer = document.getElementById('spec-container');
   this.search = new Search(this);
-
+  
   this._pinnedIds = {}; 
   this.loadPinEntries();
 
@@ -277,9 +274,9 @@ function Menu() {
                     && target.offsetHeight + target.scrollTop >= target.scrollHeight;
 
     if (offBottom) {
-      e.preventDefault();
-    }
-  });
+		  e.preventDefault();
+	  }
+  })
 }
 
 Menu.prototype.documentKeydown = function (e) {
@@ -306,7 +303,7 @@ Menu.prototype.revealInToc = function (path) {
     current[i].classList.remove('revealed');
     current[i].classList.remove('revealed-leaf');
   }
-
+  
   var current = this.$toc;
   var index = 0;
   while (index < path.length) {
@@ -317,7 +314,7 @@ Menu.prototype.revealInToc = function (path) {
         if (index === path.length - 1) {
           children[i].classList.add('revealed-leaf');
           var rect = children[i].getBoundingClientRect();
-          // this.$toc.getBoundingClientRect().top;
+          this.$toc.getBoundingClientRect().top
           var tocRect = this.$toc.getBoundingClientRect();
           if (rect.top + 10 > tocRect.bottom) {
             this.$toc.scrollTop = this.$toc.scrollTop + (rect.top - tocRect.bottom) + (rect.bottom - rect.top);
@@ -328,27 +325,29 @@ Menu.prototype.revealInToc = function (path) {
         current = children[i].querySelector('ol');
         index++;
         break;
-      }
+      }      
     }
-
+    
   }
 }
 
 function findActiveClause(root, path) {
   var clauses = new ClauseWalker(root);
   var $clause;
+  var found = false;
   var path = path || [];
-
+  
   while ($clause = clauses.nextNode()) {
     var rect = $clause.getBoundingClientRect();
-    var $header = $clause.querySelector("h1");
+    var $header = $clause.children[0];
     var marginTop = parseInt(getComputedStyle($header)["margin-top"]);
-
+    
     if ((rect.top - marginTop) <= 0 && rect.bottom > 0) {
+      found = true;
       return findActiveClause($clause, path.concat($clause)) || path;
     }
   }
-
+  
   return path;
 }
 
@@ -373,7 +372,7 @@ function ClauseWalker(root) {
     },
     false
     );
-
+  
   return treeWalker;
 }
 
@@ -456,7 +455,7 @@ Menu.prototype.loadPinEntries = function () {
   } catch (e) {
     return;
   }
-
+  
   var pinsString = window.localStorage.pinEntries;
   if (!pinsString) return;
   var pins = JSON.parse(pinsString);
@@ -487,11 +486,6 @@ function init() {
   var $container = document.getElementById('spec-container');
   $container.addEventListener('mouseover', debounce(function (e) {
     Toolbox.activateIfMouseOver(e);
-  }));
-  document.addEventListener('keydown', debounce(function (e) {
-    if (e.code === "Escape" && Toolbox.active) {
-      Toolbox.deactivate();
-    }
   }));
 }
 
@@ -591,11 +585,12 @@ function fuzzysearch (searchString, haystack, caseInsensitive) {
   var qlen = searchString.length;
   var chunks = 1;
   var finding = false;
-
+  var prefix = true;
+  
   if (qlen > tlen) {
     return false;
   }
-
+  
   if (qlen === tlen) {
     if (searchString === haystack) {
       return { caseMatch: true, chunks: 1, prefix: true };
@@ -605,7 +600,7 @@ function fuzzysearch (searchString, haystack, caseInsensitive) {
       return false;
     }
   }
-
+  
   outer: for (var i = 0, j = 0; i < qlen; i++) {
     var nch = searchString[i];
     while (j < tlen) {
@@ -619,12 +614,12 @@ function fuzzysearch (searchString, haystack, caseInsensitive) {
         finding = false;
       }
     }
-
-    if (caseInsensitive) { return false; }
-
+    
+    if (caseInsensitive) { return false }
+    
     return fuzzysearch(searchString.toLowerCase(), haystack.toLowerCase(), true);
   }
-
+  
   return { caseMatch: !caseInsensitive, chunks: chunks, prefix: j <= qlen };
 }
 
@@ -781,6 +776,7 @@ var referencePane = {
       var target = document.getElementById(id);
       var cid = findParentClauseId(target);
       var clause = menu.search.biblio.byId[cid];
+      var dupCount = 0;
       return { id: id, clause: clause }
     }).sort(function (a, b) {
       return sortByClauseNumber(a.clause, b.clause);
@@ -820,7 +816,7 @@ function sortByClauseNumber(c1, c2) {
     if (i >= c2c.length) {
       return 1;
     }
-
+    
     var c1 = c1c[i];
     var c2 = c2c[i];
     var c1cn = Number(c1);
@@ -980,43 +976,16 @@ emu-const {
 emu-val {
   font-weight: bold;
 }
-
-/* depth 1 */
-emu-alg ol,
-/* depth 4 */
-emu-alg ol ol ol ol,
-emu-alg ol.nested-thrice,
-emu-alg ol.nested-twice ol,
-emu-alg ol.nested-once ol ol {
-  list-style-type: decimal;
+emu-alg ol, emu-alg ol ol ol ol {
+    list-style-type: decimal;
 }
 
-/* depth 2 */
-emu-alg ol ol,
-emu-alg ol.nested-once,
-/* depth 5 */
-emu-alg ol ol ol ol ol,
-emu-alg ol.nested-four-times,
-emu-alg ol.nested-thrice ol,
-emu-alg ol.nested-twice ol ol,
-emu-alg ol.nested-once ol ol ol {
-  list-style-type: lower-alpha;
+emu-alg ol ol, emu-alg ol ol ol ol ol {
+    list-style-type: lower-alpha;
 }
 
-/* depth 3 */
-emu-alg ol ol ol,
-emu-alg ol.nested-twice,
-emu-alg ol.nested-once ol,
-/* depth 6 */
-emu-alg ol ol ol ol ol ol,
-emu-alg ol.nested-lots,
-emu-alg ol.nested-four-times ol,
-emu-alg ol.nested-thrice ol ol,
-emu-alg ol.nested-twice ol ol ol,
-emu-alg ol.nested-once ol ol ol ol,
-/* depth 7+ */
-emu-alg ol.nested-lots ol {
-  list-style-type: lower-roman;
+emu-alg ol ol ol, ol ol ol ol ol ol {
+    list-style-type: lower-roman;
 }
 
 emu-eqn {
@@ -1067,10 +1036,6 @@ emu-note > div.note-contents > p:last-of-type {
   margin-bottom: 0;
 }
 
-emu-table td code {
-  white-space: normal;
-} 
-
 emu-figure {
   display: block;
 }
@@ -1095,10 +1060,6 @@ emu-table figure {
 
 emu-production {
     display: block;
-}
-
-emu-grammar[type="example"] emu-production,
-emu-grammar[type="definition"] emu-production {
     margin-top: 1em;
     margin-bottom: 1em;
     margin-left: 5ex;
@@ -1106,15 +1067,9 @@ emu-grammar[type="definition"] emu-production {
 
 emu-grammar.inline, emu-production.inline,
 emu-grammar.inline emu-production emu-rhs, emu-production.inline emu-rhs,
-emu-grammar[collapsed] emu-production emu-rhs {
+emu-grammar[collapsed] emu-production emu-rhs, emu-production[collapsed] emu-rhs {
     display: inline;
     padding-left: 1ex;
-    margin-left: 0;
-}
-
-emu-production[collapsed] emu-rhs {
-    display: inline;
-    padding-left: .5ex;
     margin-left: 0;
 }
 
@@ -1124,27 +1079,26 @@ emu-grammar[collapsed] emu-production, emu-production[collapsed] {
 
 emu-constraints {
     font-size: .75em;
-    margin-right: .5ex;
+    margin-right: 1ex;
 }
 
 emu-gann {
-    margin-right: .5ex;
+    margin-right: 1ex;
 }
 
 emu-gann emu-t:last-child,
-emu-gann emu-gprose:last-child,
 emu-gann emu-nt:last-child {
     margin-right: 0;
 }
 
 emu-geq {
-    margin-left: .5ex;
+    margin-left: 1ex;
     font-weight: bold;
 }
 
 emu-oneof {
     font-weight: bold;
-    margin-left: .5ex;
+    margin-left: 1ex;
 }
 
 emu-nt {
@@ -1159,7 +1113,7 @@ emu-nt a, emu-nt a:visited {
 }
 
 emu-rhs emu-nt {
-    margin-right: .5ex;
+    margin-right: 1ex;
 }
 
 emu-t {
@@ -1171,7 +1125,7 @@ emu-t {
 }
 
 emu-production emu-t {
-    margin-right: .5ex;
+    margin-right: 1ex;
 }
 
 emu-rhs {
@@ -1185,6 +1139,10 @@ emu-mods {
     vertical-align: sub;
     font-style: normal;
     font-weight: normal;
+}
+
+emu-production[collapsed] emu-mods {
+  display: none;
 }
 
 emu-params, emu-opt {
@@ -1203,10 +1161,6 @@ emu-opt {
 emu-gprose {
     font-size: 0.9em;
     font-family: Helvetica, Arial, sans-serif;
-}
-
-emu-production emu-gprose {
-    margin-right: 1ex;
 }
 
 h1.shortname {
@@ -1236,7 +1190,7 @@ h1, h2, h3, h4, h5, h6 {
 
 h1 .secnum {
   text-decoration: none;
-  margin-right: 5px;
+  margin-right: 10px;
 }
 
 h1 span.title {
@@ -1851,41 +1805,46 @@ li.menu-search-result-term:before {
     display: none; 
   }
 }
-</style></head><body><div id="menu-toggle">☰</div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intro" title="Introduction">Introduction</a></li><li><span class="item-toggle">◢</span><a href="#intl-displaynames-objects" title="DisplayNames Objects"><span class="secnum">1</span> DisplayNames Objects</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intl-displaynames-abstracts" title="Abstract Operations for DisplayNames Objects"><span class="secnum">1.1</span> Abstract Operations for DisplayNames Objects</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-canonicalcodefordisplaynames" title="CanonicalCodeForDisplayNames ( type, code)"><span class="secnum">1.1.1</span> CanonicalCodeForDisplayNames ( <var>type</var>, <var>code</var>)</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-isvaliddatetimefieldcode" title="IsValidDateTimeFieldCode ( field )"><span class="secnum">1.2</span> <ins>IsValidDateTimeFieldCode ( <var>field</var> )</ins></a></li><li><span class="item-toggle">◢</span><a href="#sec-intl-displaynames-constructor" title="The Intl.DisplayNames Constructor"><span class="secnum">1.3</span> The Intl.DisplayNames Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-Intl.DisplayNames" title="Intl.DisplayNames ( locales, options )"><span class="secnum">1.3.1</span> Intl.DisplayNames ( <var>locales</var>, <var>options</var> )</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-intl-displaynames-constructor" title="Properties of the Intl.DisplayNames Constructor"><span class="secnum">1.4</span> Properties of the Intl.DisplayNames Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-Intl.DisplayNames.prototype" title="Intl.DisplayNames.prototype"><span class="secnum">1.4.1</span> Intl.DisplayNames.prototype</a></li><li><span class="item-toggle-none"></span><a href="#sec-Intl.DisplayNames.supportedLocalesOf" title="Intl.DisplayNames.supportedLocalesOf ( locales [ , options ] )"><span class="secnum">1.4.2</span> Intl.DisplayNames.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-Intl.DisplayNames-internal-slots" title="Internal slots"><span class="secnum">1.4.3</span> Internal slots</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-intl-displaynames-prototype-object" title="Properties of the Intl.DisplayNames Prototype Object"><span class="secnum">1.5</span> Properties of the Intl.DisplayNames Prototype Object</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-Intl.DisplayNames.prototype.constructor" title="Intl.DisplayNames.prototype.constructor"><span class="secnum">1.5.1</span> Intl.DisplayNames.prototype.constructor</a></li><li><span class="item-toggle-none"></span><a href="#sec-Intl.DisplayNames.prototype-@@tostringtag" title="Intl.DisplayNames.prototype[ @@toStringTag ]"><span class="secnum">1.5.2</span> Intl.DisplayNames.prototype[ @@toStringTag ]</a></li><li><span class="item-toggle-none"></span><a href="#sec-Intl.DisplayNames.prototype.of" title="Intl.DisplayNames.prototype.of ( code )"><span class="secnum">1.5.3</span> Intl.DisplayNames.prototype.of ( <var>code</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-Intl.DisplayNames.prototype.resolvedOptions" title="Intl.DisplayNames.prototype.resolvedOptions ( )"><span class="secnum">1.5.4</span> Intl.DisplayNames.prototype.resolvedOptions ( )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-properties-of-intl-displaynames-instances" title="Properties of Intl.DisplayNames Instances"><span class="secnum">1.6</span> Properties of Intl.DisplayNames Instances</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-copyright-and-software-license" title="Copyright &amp; Software License"><span class="secnum">A</span> Copyright &amp; Software License</a></li></ol></div></div><div id="spec-container"><h1 class="version first">Stage 2 Draft / April 19, 2021</h1><h1 class="title">Intl.DisplayNames v2 Proposal</h1>
+</style></head><body><div id="menu-toggle">☰</div><div id="menu-spacer"></div><div id="menu"><div id="menu-search"><input type="text" id="menu-search-box" placeholder="Search..."><div id="menu-search-results" class="inactive"></div></div><div id="menu-pins"><div class="menu-pane-header">Pins</div><ul id="menu-pins-list"></ul></div><div class="menu-pane-header">Table of Contents</div><div id="menu-toc"><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-intro" title="Introduction">Introduction</a></li><li><span class="item-toggle">◢</span><a href="#intl-displaynames-objects" title="DisplayNames Objects"><span class="secnum">1</span> DisplayNames Objects</a><ol class="toc"><li><span class="item-toggle">◢</span><a href="#sec-intl-displaynames-abstracts" title="Abstract Operations for DisplayNames Objects"><span class="secnum">1.1</span> Abstract Operations for DisplayNames Objects</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-canonicalcodefordisplaynames" title="CanonicalCodeForDisplayNames ( type, code)"><span class="secnum">1.1.1</span> CanonicalCodeForDisplayNames ( <var>type</var>, <var>code</var>)</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-isvaliddatetimefieldcode" title="IsValidDateTimeFieldCode ( field )"><span class="secnum">1.2</span> <ins>IsValidDateTimeFieldCode ( <var>field</var> )</ins></a></li><li><span class="item-toggle">◢</span><a href="#sec-intl-displaynames-constructor" title="The Intl.DisplayNames Constructor"><span class="secnum">1.3</span> The Intl.DisplayNames Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-Intl.DisplayNames" title="Intl.DisplayNames ( locales, options )"><span class="secnum">1.3.1</span> Intl.DisplayNames ( <var>locales</var>, <var>options</var> )</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-intl-displaynames-constructor" title="Properties of the Intl.DisplayNames Constructor"><span class="secnum">1.4</span> Properties of the Intl.DisplayNames Constructor</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-Intl.DisplayNames.prototype" title="Intl.DisplayNames.prototype"><span class="secnum">1.4.1</span> Intl.DisplayNames.prototype</a></li><li><span class="item-toggle-none"></span><a href="#sec-Intl.DisplayNames.supportedLocalesOf" title="Intl.DisplayNames.supportedLocalesOf ( locales [ , options ] )"><span class="secnum">1.4.2</span> Intl.DisplayNames.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )</a></li><li><span class="item-toggle-none"></span><a href="#sec-Intl.DisplayNames-internal-slots" title="Internal slots"><span class="secnum">1.4.3</span> Internal slots</a></li></ol></li><li><span class="item-toggle">◢</span><a href="#sec-properties-of-intl-displaynames-prototype-object" title="Properties of the Intl.DisplayNames Prototype Object"><span class="secnum">1.5</span> Properties of the Intl.DisplayNames Prototype Object</a><ol class="toc"><li><span class="item-toggle-none"></span><a href="#sec-Intl.DisplayNames.prototype.constructor" title="Intl.DisplayNames.prototype.constructor"><span class="secnum">1.5.1</span> Intl.DisplayNames.prototype.constructor</a></li><li><span class="item-toggle-none"></span><a href="#sec-Intl.DisplayNames.prototype-@@tostringtag" title="Intl.DisplayNames.prototype[ @@toStringTag ]"><span class="secnum">1.5.2</span> Intl.DisplayNames.prototype[ @@toStringTag ]</a></li><li><span class="item-toggle-none"></span><a href="#sec-Intl.DisplayNames.prototype.of" title="Intl.DisplayNames.prototype.of ( code )"><span class="secnum">1.5.3</span> Intl.DisplayNames.prototype.of ( <var>code</var> )</a></li><li><span class="item-toggle-none"></span><a href="#sec-Intl.DisplayNames.prototype.resolvedOptions" title="Intl.DisplayNames.prototype.resolvedOptions ( )"><span class="secnum">1.5.4</span> Intl.DisplayNames.prototype.resolvedOptions ( )</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-properties-of-intl-displaynames-instances" title="Properties of Intl.DisplayNames Instances"><span class="secnum">1.6</span> Properties of Intl.DisplayNames Instances</a></li></ol></li><li><span class="item-toggle-none"></span><a href="#sec-copyright-and-software-license" title="Copyright &amp; Software License"><span class="secnum">A</span> Copyright &amp; Software License</a></li></ol></div></div><div id="spec-container"><h1 class="version first">Stage 2 Draft / April 20, 2021</h1><h1 class="title">Intl.DisplayNames v2 Proposal</h1>
 
 <emu-intro id="sec-intro">
   <h1>Introduction</h1>
 
   <p>This proposal enhances the Intl.DisplayNames API and cover more display names for weekday, month, time zone, unit, calendar, numbering system, etc.
-  See <a href="https://github.com/tc39/intl-displaynames-v2/blob/main/README.md">the README</a> for more context.</p>
+  See  <a href="https://github.com/tc39/intl-displaynames-v2/blob/main/README.md">the README</a> for more context.</p>
 </emu-intro>
 
 <emu-biblio href="./biblio.json"></emu-biblio>
-<emu-import href="./displaynames.html"><emu-biblio href="./biblio.json"></emu-biblio><emu-clause id="intl-displaynames-objects">
-  <h1><span class="secnum">1</span> DisplayNames Objects</h1>
+<emu-import href="./displaynames.html"><emu-biblio href="./biblio.json"></emu-biblio>
+<emu-clause id="intl-displaynames-objects">
+  <h1><span class="secnum">1</span>DisplayNames Objects</h1>
 
   <emu-clause id="sec-intl-displaynames-abstracts">
-    <h1><span class="secnum">1.1</span> Abstract Operations for DisplayNames Objects</h1>
+    <h1><span class="secnum">1.1</span>Abstract Operations for DisplayNames Objects</h1>
 
     <emu-clause id="sec-canonicalcodefordisplaynames" aoid="CanonicalCodeForDisplayNames">
-      <h1><span class="secnum">1.1.1</span> CanonicalCodeForDisplayNames ( <var>type</var>, <var>code</var>)</h1>
+      <h1><span class="secnum">1.1.1</span>CanonicalCodeForDisplayNames ( <var>type</var>, <var>code</var>)</h1>
       <p>
-      The CanonicalCodeForDisplayNames abstract operation is called with arguments <var>type</var>, <var>code</var>. It verifies that the <var>code</var> argument represents a well-formed code according to the <var>type</var> argument and returns the case-regularized form of the <var>code</var>. The algorithm refers to <a href="https://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>. The following steps are taken:
+      The CanonicalCodeForDisplayNames abstract operation is called with arguments <var>type</var>, <var>code</var>. It verifies that the <var>code</var> argument represents a well-formed code according to the <var>type</var> argument and returns the case-regularized form of the <var>code</var>. The algorithm refers to  <a href="https://www.unicode.org/reports/tr35/#Identifiers">UTS 35's Unicode Language and Locale Identifiers grammar</a>. The following steps are taken:
+      
       </p>
-      <emu-alg><ol><li>If <var>type</var> is <code>"language"</code>, then<ol><li>If <var>code</var> does not matches the <code>unicode_language_id</code> production, throw a <emu-val>RangeError</emu-val> exceptipon.</li><li>If <emu-xref aoid="IsStructurallyValidLanguageTag"><a href="https://tc39.es/ecma402/#sec-isstructurallyvalidlanguagetag">IsStructurallyValidLanguageTag</a></emu-xref>(<var>code</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Set <var>code</var> to <emu-xref aoid="CanonicalizeUnicodeLocaleId"><a href="https://tc39.es/ecma402/#sec-canonicalizeunicodelocaleid">CanonicalizeUnicodeLocaleId</a></emu-xref>(<var>code</var>).</li><li>Return <var>code</var>.</li></ol></li><li>If <var>type</var> is <code>"region"</code>, then<ol><li>If <var>code</var> does not matches the <code>unicode_region_subtag</code> production, throw a <emu-val>RangeError</emu-val> exceptipon.</li><li>Let <var>code</var> be the result of mapping <var>code</var> to upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"><a href="https://tc39.es/ecma402/#sec-case-sensitivity-and-case-mapping">6.1</a></emu-xref>.</li><li>Return <var>code</var>.</li></ol></li><li>If <var>type</var> is <code>"script"</code>, then<ol><li>If <var>code</var> does not matches the <code>unicode_script_subtag</code> production, throw a <emu-val>RangeError</emu-val> exceptipon.</li><li>Let <var>code</var> be the result of mapping the first character in <var>code</var> to upper case, and mapping the second, third and fourth character in <var>code</var> to lower case, as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"><a href="https://tc39.es/ecma402/#sec-case-sensitivity-and-case-mapping">6.1</a></emu-xref>.</li><li>Return <var>code</var>.</li></ol></li><li><ins>If <var>type</var> is <code>"calendar"</code>, then</ins><ol><li><ins>If <var>code</var> does not match the Unicode Locale Identifier <code>type</code> nonterminal, throw a <emu-val>RangeError</emu-val> exception.</ins></li><li><ins>Let <var>code</var> be the result of mapping <var>code</var> to lower case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"><a href="https://tc39.es/ecma402/#sec-case-sensitivity-and-case-mapping">6.1</a></emu-xref>.</ins></li><li><ins>Return <var>code</var>.</ins></li></ol></li><li><ins>If <var>type</var> is <code>"unit"</code>, then</ins><ol><li><ins>If the result of <emu-xref aoid="IsWellFormedUnitIdentifier"><a href="https://tc39.es/ecma402/#sec-iswellformedunitidentifier">IsWellFormedUnitIdentifier</a></emu-xref>(<var>code</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</ins></li><li><ins>Return <var>code</var>.</ins></li></ol></li><li><ins>If <var>type</var> is <code>"dateTimeField"</code>, then</ins><ol><li><ins>If the result of <emu-xref aoid="IsValidDateTimeFieldCode" id="_ref_8"><a href="#sec-isvaliddatetimefieldcode">IsValidDateTimeFieldCode</a></emu-xref>(<var>code</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</ins></li><li><ins>Return <var>code</var>.</ins></li></ol></li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>type</var> is <code>"currency"</code>.</li><li>If !&nbsp;<emu-xref aoid="IsWellFormedCurrencyCode"><a href="https://tc39.es/ecma402/#sec-iswellformedcurrencycode">IsWellFormedCurrencyCode</a></emu-xref>(<var>code</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exceptipon.</li><li>Let <var>code</var> be the result of mapping <var>code</var> to upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"><a href="https://tc39.es/ecma402/#sec-case-sensitivity-and-case-mapping">6.1</a></emu-xref>.</li><li>Return <var>code</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>If <var>type</var> is <code>"language"</code>, then<ol><li>If <var>code</var> does not matches the <code>unicode_language_id</code> production, throw a <emu-val>RangeError</emu-val> exceptipon.</li><li>If <emu-xref aoid="IsStructurallyValidLanguageTag"><a href="https://tc39.es/ecma402/#sec-isstructurallyvalidlanguagetag">IsStructurallyValidLanguageTag</a></emu-xref>(<var>code</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</li><li>Set <var>code</var> to <emu-xref aoid="CanonicalizeUnicodeLocaleId"><a href="https://tc39.es/ecma402/#sec-canonicalizeunicodelocaleid">CanonicalizeUnicodeLocaleId</a></emu-xref>(<var>code</var>).</li><li>Return <var>code</var>.</li></ol></li><li>If <var>type</var> is <code>"region"</code>, then<ol><li>If <var>code</var> does not matches the <code>unicode_region_subtag</code> production, throw a <emu-val>RangeError</emu-val> exceptipon.</li><li>Let <var>code</var> be the result of mapping <var>code</var> to upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"><a href="https://tc39.es/ecma402/#sec-case-sensitivity-and-case-mapping">6.1</a></emu-xref>.</li><li>Return <var>code</var>.</li></ol></li><li>If <var>type</var> is <code>"script"</code>, then<ol><li>If <var>code</var> does not matches the <code>unicode_script_subtag</code> production, throw a <emu-val>RangeError</emu-val> exceptipon.</li><li>Let <var>code</var> be the result of mapping the first character in <var>code</var> to upper case, and mapping the second, third and fourth character in <var>code</var> to lower case, as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"><a href="https://tc39.es/ecma402/#sec-case-sensitivity-and-case-mapping">6.1</a></emu-xref>.</li><li>Return <var>code</var>.</li></ol></li><li><ins>If <var>type</var> is <code>"calendar"</code>, then</ins><ol><li><ins>If <var>code</var> does not match the Unicode Locale Identifier <code>type</code> nonterminal, throw a <emu-val>RangeError</emu-val> exception.</ins></li><li><ins>Let <var>code</var> be the result of mapping <var>code</var> to lower case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"><a href="https://tc39.es/ecma402/#sec-case-sensitivity-and-case-mapping">6.1</a></emu-xref>.</ins></li><li><ins>Return <var>code</var>.</ins></li></ol></li><li><ins>If <var>type</var> is <code>"unit"</code>, then</ins><ol><li><ins>If the result of <emu-xref aoid="IsWellFormedUnitIdentifier"><a href="https://tc39.es/ecma402/#sec-iswellformedunitidentifier">IsWellFormedUnitIdentifier</a></emu-xref>(<var>code</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</ins></li><li><ins>Return <var>code</var>.</ins></li></ol></li><li><ins>If <var>type</var> is <code>"dateTimeField"</code>, then</ins><ol><li><ins>If the result of <emu-xref aoid="IsValidDateTimeFieldCode" id="_ref_8"><a href="#sec-isvaliddatetimefieldcode">IsValidDateTimeFieldCode</a></emu-xref>(<var>code</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exception.</ins></li><li><ins>Return <var>code</var>.</ins></li></ol></li><li>Assert: <var>type</var> is <code>"currency"</code>.</li><li>If !&nbsp;<emu-xref aoid="IsWellFormedCurrencyCode"><a href="https://tc39.es/ecma402/#sec-iswellformedcurrencycode">IsWellFormedCurrencyCode</a></emu-xref>(<var>code</var>) is <emu-val>false</emu-val>, throw a <emu-val>RangeError</emu-val> exceptipon.</li><li>Let <var>code</var> be the result of mapping <var>code</var> to upper case as described in <emu-xref href="#sec-case-sensitivity-and-case-mapping"><a href="https://tc39.es/ecma402/#sec-case-sensitivity-and-case-mapping">6.1</a></emu-xref>.</li><li>Return <var>code</var>.
+      </li></ol></emu-alg>
     </emu-clause>
   </emu-clause>
 
     <emu-clause id="sec-isvaliddatetimefieldcode" aoid="IsValidDateTimeFieldCode">
-      <h1><span class="secnum">1.2</span> <ins>IsValidDateTimeFieldCode ( <var>field</var> )</ins></h1>
+      <h1><span class="secnum">1.2</span><ins>IsValidDateTimeFieldCode ( <var>field</var> )</ins></h1>
       <p>
       <ins>
         The IsValidDateTimeFieldCode abstract operation is called with arguments <var>field</var>. It verifies that the <var>field</var> argument represents a valid date time field code. The following steps are taken:
+      
       </ins>
       </p>
-      <emu-alg><ol><li><ins>If <var>field</var> is listed in <emu-xref href="#table-validcodefordatetimefield" id="_ref_0"><a href="#table-validcodefordatetimefield">Table 1</a></emu-xref>, return <emu-val>true</emu-val>.</ins></li><li><ins>Return <emu-val>false</emu-val>.</ins></li></ol></emu-alg>
+      <emu-alg><ol><li><ins>If <var>field</var> is listed in <emu-xref href="#table-validcodefordatetimefield" id="_ref_0"><a href="#table-validcodefordatetimefield">Table 1</a></emu-xref>, return <emu-val>true</emu-val>.</ins></li><li><ins>Return <emu-val>false</emu-val>.</ins>
+      </li></ol></emu-alg>
 
-      <emu-table id="table-validcodefordatetimefield"><figure><figcaption>Table 1: <ins>Codes For Date Time Field of DisplayNames</ins></figcaption>
+      <emu-table id="table-validcodefordatetimefield"><figure><figcaption>Table 1:  <ins>Codes For Date Time Field of DisplayNames</ins></figcaption>
         
         <table class="real-table">
           <thead>
@@ -1948,129 +1907,148 @@ li.menu-search-result-term:before {
     </emu-clause>
 
   <emu-clause id="sec-intl-displaynames-constructor">
-    <h1><span class="secnum">1.3</span> The Intl.DisplayNames Constructor</h1>
+    <h1><span class="secnum">1.3</span>The Intl.DisplayNames Constructor</h1>
 
     <p>
-      The DisplayNames <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> is a standard built-in property of the Intl object.</p>
+      The DisplayNames constructor is a standard built-in property of the Intl object.</p>
 
     <emu-clause id="sec-Intl.DisplayNames">
-      <h1><span class="secnum">1.3.1</span> Intl.DisplayNames ( <var>locales</var>, <var>options</var> )</h1>
+      <h1><span class="secnum">1.3.1</span>Intl.DisplayNames ( <var>locales</var>, <var>options</var> )</h1>
 
       <p>
         When the <emu-val>Intl.DisplayNames</emu-val> function is called with arguments <var>locales</var> and <var>options</var>, the following steps are taken:
+      
       </p>
 
-      <emu-alg><ol><li>If NewTarget is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>displayNames</var> be ?&nbsp;<emu-xref aoid="OrdinaryCreateFromConstructor" id="_ref_9"><a href="https://tc39.es/ecma262/#sec-ordinarycreatefromconstructor">OrdinaryCreateFromConstructor</a></emu-xref>(NewTarget, <code>"%DisplayNamesPrototype%"</code>, « [[InitializedDisplayNames]], [[Locale]], [[Style]], [[Type]], [[Fallback]], <ins>[[DialectHandling]], </ins>[[Fields]] »).</li><li>Let <var>requestedLocales</var> be ?&nbsp;<emu-xref aoid="CanonicalizeLocaleList"><a href="https://tc39.es/ecma402/#sec-canonicalizelocalelist">CanonicalizeLocaleList</a></emu-xref>(<var>locales</var>).</li><li>Let <var>options</var> be ?&nbsp;<emu-xref aoid="ToObject" id="_ref_10"><a href="https://tc39.es/ecma262/#sec-toobject">ToObject</a></emu-xref>(<var>options</var>).</li><li>Let <var>opt</var> be a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>.</li><li>Let <var>localeData</var> be %DisplayNames%.[[LocaleData]].</li><li>Let <var>matcher</var> be ?&nbsp;<emu-xref aoid="GetOption"><a href="https://tc39.es/ecma402/#sec-getoption">GetOption</a></emu-xref>(<var>options</var>, <code>"localeMatcher"</code>, <code>"string"</code>, « <code>"lookup"</code>, <code>"best fit"</code> », <code>"best fit"</code>).</li><li>Set <var>opt</var>.[[localeMatcher]] to <var>matcher</var>.</li><li>Let <var>r</var> be <emu-xref aoid="ResolveLocale"><a href="https://tc39.es/ecma402/#sec-resolvelocale">ResolveLocale</a></emu-xref>(%DisplayNames%.[[AvailableLocales]], <var>requestedLocales</var>, <var>opt</var>, %DisplayNames%.[[RelevantExtensionKeys]]).</li><li>Let <var>style</var> be ?&nbsp;<emu-xref aoid="GetOption"><a href="https://tc39.es/ecma402/#sec-getoption">GetOption</a></emu-xref>(<var>options</var>, <code>"style"</code>, <code>"string"</code>, « <code>"narrow"</code>, <code>"short"</code>, <code>"long"</code> », <code>"long"</code>).</li><li>Set <var>displayNames</var>.[[Style]] to <var>style</var>.</li><li>Let <var>type</var> be ?&nbsp;<emu-xref aoid="GetOption"><a href="https://tc39.es/ecma402/#sec-getoption">GetOption</a></emu-xref>(<var>options</var>, <code>"type"</code>, <code>"string"</code>, « <code>"language"</code>, <code>"region"</code>, <code>"script"</code>, <code>"currency"</code> <ins>, <code>"calendar"</code>, <code>"dateTimeField"</code>, <code>"unit"</code></ins>», <emu-val>undefined</emu-val>).</li><li>If <var>type</var> is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Set <var>displayNames</var>.[[Type]] to <var>type</var>.</li><li>Let <var>fallback</var> be ?&nbsp;<emu-xref aoid="GetOption"><a href="https://tc39.es/ecma402/#sec-getoption">GetOption</a></emu-xref>(<var>options</var>, <code>"fallback"</code>, <code>"string"</code>, « <code>"code"</code>, <code>"none"</code> », <code>"code"</code>).</li><li>Set <var>displayNames</var>.[[Fallback]] to <var>fallback</var>.</li><li>Set <var>displayNames</var>.[[Locale]] to the value of <var>r</var>.[[Locale]].</li><li>Let <var>dataLocale</var> be <var>r</var>.[[dataLocale]].</li><li>Let <var>dataLocaleData</var> be <var>localeData</var>.[[&lt;<var>dataLocale</var>&gt;]].</li><li>Let <var>types</var> be <var>dataLocaleData</var>.[[types]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>types</var> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots" id="_ref_1"><a href="#sec-Intl.DisplayNames-internal-slots">1.4.3</a></emu-xref>).</li><li>Let <var>typeFields</var> be <var>types</var>.[[&lt;<var>type</var>&gt;]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>typeFields</var> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots" id="_ref_2"><a href="#sec-Intl.DisplayNames-internal-slots">1.4.3</a></emu-xref>).</li><li><ins>If <var>type</var> is <code>"language"</code>, then</ins><ol><li><ins>Let <var>dialectHandling</var> be ?&nbsp;<emu-xref aoid="GetOption"><a href="https://tc39.es/ecma402/#sec-getoption">GetOption</a></emu-xref>(<var>options</var>, <code>"dialectHandling"</code>, <code>"string"</code>, « <code>"dialectName"</code>, <code>"standardName"</code> », <code>"dialectName"</code>).</ins></li><li><ins>Set <var>displayNames</var>.[[DialectHandling]] to <var>dialectHandling</var>.</ins></li><li><ins>Let <var>typeFields</var> be <var>typeFields</var>.[[&lt;<var>dialectHandling</var>&gt;]].</ins></li><li><ins><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>typeFields</var> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots" id="_ref_3"><a href="#sec-Intl.DisplayNames-internal-slots">1.4.3</a></emu-xref>).</ins></li></ol></li><li>Let <var>styleFields</var> be <var>typeFields</var>.[[&lt;<var>style</var>&gt;]].</li><li><emu-xref href="#assert"><a href="https://tc39.es/ecma262/#assert">Assert</a></emu-xref>: <var>styleFields</var> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots" id="_ref_4"><a href="#sec-Intl.DisplayNames-internal-slots">1.4.3</a></emu-xref>).</li><li>Set <var>displayNames</var>.[[Fields]] to <var>styleFields</var>.</li><li>Return <var>displayNames</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>If NewTarget is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>displayNames</var> be ?&nbsp;<emu-xref aoid="OrdinaryCreateFromConstructor" id="_ref_9"><a href="https://tc39.github.io/ecma262/#sec-ordinarycreatefromconstructor">OrdinaryCreateFromConstructor</a></emu-xref>(NewTarget, <code>"%DisplayNamesPrototype%"</code>, « [[InitializedDisplayNames]], [[Locale]], [[Style]], [[Type]], [[Fallback]], <ins>[[DialectHandling]], </ins>[[Fields]] »).</li><li>Let <var>requestedLocales</var> be ?&nbsp;<emu-xref aoid="CanonicalizeLocaleList"><a href="https://tc39.es/ecma402/#sec-canonicalizelocalelist">CanonicalizeLocaleList</a></emu-xref>(<var>locales</var>).</li><li>Let <var>options</var> be ?&nbsp;<emu-xref aoid="ToObject" id="_ref_10"><a href="https://tc39.github.io/ecma262/#sec-toobject">ToObject</a></emu-xref>(<var>options</var>).</li><li>Let <var>opt</var> be a new <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>.</li><li>Let <var>localeData</var> be %DisplayNames%.[[LocaleData]].</li><li>Let <var>matcher</var> be ?&nbsp;<emu-xref aoid="GetOption"><a href="https://tc39.es/ecma402/#sec-getoption">GetOption</a></emu-xref>(<var>options</var>, <code>"localeMatcher"</code>, <code>"string"</code>, « <code>"lookup"</code>, <code>"best fit"</code> », <code>"best fit"</code>).</li><li>Set <var>opt</var>.[[localeMatcher]] to <var>matcher</var>.</li><li>Let <var>r</var> be <emu-xref aoid="ResolveLocale"><a href="https://tc39.es/ecma402/#sec-resolvelocale">ResolveLocale</a></emu-xref>(%DisplayNames%.[[AvailableLocales]], <var>requestedLocales</var>, <var>opt</var>, %DisplayNames%.[[RelevantExtensionKeys]]).</li><li>Let <var>style</var> be ?&nbsp;<emu-xref aoid="GetOption"><a href="https://tc39.es/ecma402/#sec-getoption">GetOption</a></emu-xref>(<var>options</var>, <code>"style"</code>, <code>"string"</code>, « <code>"narrow"</code>, <code>"short"</code>, <code>"long"</code> », <code>"long"</code>).</li><li>Set <var>displayNames</var>.[[Style]] to <var>style</var>.</li><li>Let <var>type</var> be ?&nbsp;<emu-xref aoid="GetOption"><a href="https://tc39.es/ecma402/#sec-getoption">GetOption</a></emu-xref>(<var>options</var>, <code>"type"</code>, <code>"string"</code>, « <code>"language"</code>, <code>"region"</code>, <code>"script"</code>, <code>"currency"</code> <ins>, <code>"calendar"</code>, <code>"dateTimeField"</code>, <code>"unit"</code></ins>», <emu-val>undefined</emu-val>).</li><li>If <var>type</var> is <emu-val>undefined</emu-val>, throw a <emu-val>TypeError</emu-val> exception.</li><li>Set <var>displayNames</var>.[[Type]] to <var>type</var>.</li><li>Let <var>fallback</var> be ?&nbsp;<emu-xref aoid="GetOption"><a href="https://tc39.es/ecma402/#sec-getoption">GetOption</a></emu-xref>(<var>options</var>, <code>"fallback"</code>, <code>"string"</code>, « <code>"code"</code>, <code>"none"</code> », <code>"code"</code>).</li><li>Set <var>displayNames</var>.[[Fallback]] to <var>fallback</var>.</li><li>Set <var>displayNames</var>.[[Locale]] to the value of <var>r</var>.[[Locale]].</li><li>Let <var>dataLocale</var> be <var>r</var>.[[dataLocale]].</li><li>Let <var>dataLocaleData</var> be <var>localeData</var>.[[&lt;<var>dataLocale</var>&gt;]].</li><li>Let <var>types</var> be <var>dataLocaleData</var>.[[types]].</li><li>Assert: <var>types</var> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots" id="_ref_1"><a href="#sec-Intl.DisplayNames-internal-slots">1.4.3</a></emu-xref>).</li><li>Let <var>typeFields</var> be <var>types</var>.[[&lt;<var>type</var>&gt;]].</li><li>Assert: <var>typeFields</var> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots" id="_ref_2"><a href="#sec-Intl.DisplayNames-internal-slots">1.4.3</a></emu-xref>).</li><li><ins>If <var>type</var> is <code>"language"</code>, then</ins><ol><li><ins>Let <var>dialectHandling</var> be ?&nbsp;<emu-xref aoid="GetOption"><a href="https://tc39.es/ecma402/#sec-getoption">GetOption</a></emu-xref>(<var>options</var>, <code>"dialectHandling"</code>, <code>"string"</code>, « <code>"dialect"</code>, <code>"standard"</code> », <code>"dialect"</code>).</ins></li><li><ins>Set <var>displayNames</var>.[[DialectHandling]] to <var>dialectHandling</var>.</ins></li><li><ins>Let <var>typeFields</var> be <var>typeFields</var>.[[&lt;<var>dialectHandling</var>&gt;]].</ins></li><li><ins>Assert: <var>typeFields</var> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots" id="_ref_3"><a href="#sec-Intl.DisplayNames-internal-slots">1.4.3</a></emu-xref>).</ins></li></ol></li><li>Let <var>styleFields</var> be <var>typeFields</var>.[[&lt;<var>style</var>&gt;]].</li><li>Assert: <var>styleFields</var> is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots" id="_ref_4"><a href="#sec-Intl.DisplayNames-internal-slots">1.4.3</a></emu-xref>).</li><li>Set <var>displayNames</var>.[[Fields]] to <var>styleFields</var>.</li><li>Return <var>displayNames</var>.
+      </li></ol></emu-alg>
     </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-properties-of-intl-displaynames-constructor">
-    <h1><span class="secnum">1.4</span> Properties of the Intl.DisplayNames Constructor</h1>
+    <h1><span class="secnum">1.4</span>Properties of the Intl.DisplayNames Constructor</h1>
 
     <p>
-      The Intl.DisplayNames <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref> has the following properties:
+      The Intl.DisplayNames constructor has the following properties:
+    
     </p>
 
     <emu-clause id="sec-Intl.DisplayNames.prototype">
-      <h1><span class="secnum">1.4.1</span> Intl.DisplayNames.prototype</h1>
+      <h1><span class="secnum">1.4.1</span>Intl.DisplayNames.prototype</h1>
 
       <p>
         The value of <emu-val>Intl.DisplayNames.prototype</emu-val> is <emu-val>%DisplayNamesPrototype%</emu-val>.
+      
       </p>
       <p>
         This property has the attributes { [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>false</emu-val> }.
+      
       </p>
     </emu-clause>
 
     <emu-clause id="sec-Intl.DisplayNames.supportedLocalesOf">
-      <h1><span class="secnum">1.4.2</span> Intl.DisplayNames.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )</h1>
+      <h1><span class="secnum">1.4.2</span>Intl.DisplayNames.supportedLocalesOf ( <var>locales</var> [ , <var>options</var> ] )</h1>
 
       <p>
         When the <emu-val>supportedLocalesOf</emu-val> method of <emu-val>%DisplayNames%</emu-val> is called, the following steps are taken:
+      
       </p>
 
-      <emu-alg><ol><li>Let <var>availableLocales</var> be <emu-val>%DisplayNames%</emu-val>.[[AvailableLocales]].</li><li>Let <var>requestedLocales</var> be ?&nbsp;<emu-xref aoid="CanonicalizeLocaleList"><a href="https://tc39.es/ecma402/#sec-canonicalizelocalelist">CanonicalizeLocaleList</a></emu-xref>(<var>locales</var>).</li><li>Return ?&nbsp;<emu-xref aoid="SupportedLocales"><a href="https://tc39.es/ecma402/#sec-supportedlocales">SupportedLocales</a></emu-xref>(<var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var>).</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>availableLocales</var> be <emu-val>%DisplayNames%</emu-val>.[[AvailableLocales]].</li><li>Let <var>requestedLocales</var> be ?&nbsp;<emu-xref aoid="CanonicalizeLocaleList"><a href="https://tc39.es/ecma402/#sec-canonicalizelocalelist">CanonicalizeLocaleList</a></emu-xref>(<var>locales</var>).</li><li>Return ?&nbsp;<emu-xref aoid="SupportedLocales"><a href="https://tc39.es/ecma402/#sec-supportedlocales">SupportedLocales</a></emu-xref>(<var>availableLocales</var>, <var>requestedLocales</var>, <var>options</var>).
+      </li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-Intl.DisplayNames-internal-slots">
-      <h1><span class="secnum">1.4.3</span> Internal slots</h1>
+      <h1><span class="secnum">1.4.3</span>Internal slots</h1>
 
       <p>
-        The value of the [[AvailableLocales]] internal slot is implementation defined within the constraints described in <emu-xref href="#sec-internal-slots"><a href="https://tc39.es/ecma402/#sec-internal-slots">9.1</a></emu-xref>.
+        The value of the [[AvailableLocales]] internal slot is implementation defined within the constraints described in  <emu-xref href="#sec-internal-slots"><a href="https://tc39.es/ecma402/#sec-internal-slots">9.1</a></emu-xref>.
+      
       </p>
 
       <p>
         The value of the [[RelevantExtensionKeys]] internal slot is « ».
+      
       </p>
 
       <p>
-        The value of the [[LocaleData]] internal slot is implementation defined within the constraints described in <emu-xref href="#sec-internal-slots"><a href="https://tc39.es/ecma402/#sec-internal-slots">9.1</a></emu-xref> and the following additional constraints:
+        The value of the [[LocaleData]] internal slot is implementation defined within the constraints described in  <emu-xref href="#sec-internal-slots"><a href="https://tc39.es/ecma402/#sec-internal-slots">9.1</a></emu-xref> and the following additional constraints:
+      
       </p>
 
       <ul>
-        <li>[[LocaleData]].[[&lt;<var>locale</var>&gt;]] must have a [[types]] field for all locale values <var>locale</var>. The value of this field must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>, which must have fields with the names of one of the valid display name types: <code>"language"</code>, <code>"region"</code>, <code>"script"</code>, <del>and</del> <code>"currency"</code><ins>, <code>"calendar"</code>, <code>"dateTimeField"</code>, and <code>"unit"</code></ins>.</li>
-        <li><ins>The value of the field <code>"language"</code> must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> which must have fields with the names of one of the valid display name dialect handlings: <code>"dialectName"</code>, and <code>"standardName"</code>.</ins></li>
+        <li>[[LocaleData]].[[&lt;<var>locale</var>&gt;]] must have a [[types]] field for all locale values <var>locale</var>. The value of this field must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref>, which must have fields with the names of one of the valid display name types: <code>"language"</code>, <code>"region"</code>, <code>"script"</code>,  <del>and</del> <code>"currency"</code><ins>, <code>"calendar"</code>, <code>"dateTimeField"</code>, and <code>"unit"</code></ins>.</li>
+        <li><ins>The value of the field <code>"language"</code> must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> which must have fields with the names of one of the valid display name dialect handlings: <code>"dialect"</code>, and <code>"standard"</code>.</ins></li>
         <li><ins>The display name dialect handling fields under display name type <code>"language"</code> should contain Records which must have fields with the names of one of the valid display name styles: <code>"narrow"</code>, <code>"short"</code>, and <code>"long"</code>.</ins></li>
-        <li>The value of fields <del><code>"language"</code>, </del><code>"region"</code>, <code>"script"</code>, <del>and </del><code>"currency"</code><ins>, <code>"calendar"</code>, <code>"dateTimeField"</code>, and <code>"unit"</code></ins> must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> which must have fields with the names of one of the valid display name styles: <code>"narrow"</code>, <code>"short"</code>, and <code>"long"</code>.</li>
+        <li>The value of fields  <del><code>"language"</code>,  </del><code>"region"</code>, <code>"script"</code>,  <del>and  </del><code>"currency"</code><ins>, <code>"calendar"</code>, <code>"dateTimeField"</code>, and <code>"unit"</code></ins> must be a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> which must have fields with the names of one of the valid display name styles: <code>"narrow"</code>, <code>"short"</code>, and <code>"long"</code>.</li>
         <li>The display name styles fields under display name type <code>"language"</code> should contain Records, with keys corresponding to language codes according to <code>unicode_language_id</code> production. The value of these fields must be string values.</li>
         <li>The display name styles fields under display name type <code>"region"</code> should contain Records, with keys corresponding to region codes. The value of these fields must be string values.</li>
         <li>The display name styles fields under display name type <code>"script"</code> should contain Records, with keys corresponding to script codes. The value of these fields must be string values.</li>
         <li>The display name styles fields under display name type <code>"currency"</code> should contain Records, with keys corresponding to currency codes. The value of these fields must be string values.</li>
         <li><ins>The display name styles fields under display name type <code>"calendar"</code> should contain Records, with keys corresponding to a String value with the "type" given in Unicode Technical Standard 35 for the calendar used for formatting. The value of these fields must be string values.</ins></li>
-        <li><ins>The display name styles fields under display name type <code>"dateTimeField"</code> should contain Records, with keys corresponding to codes listed in <emu-xref href="#table-validcodefordatetimefield" id="_ref_5"><a href="#table-validcodefordatetimefield">Table 1</a></emu-xref>. The value of these fields must be string values.</ins></li>
+        <li><ins>The display name styles fields under display name type <code>"dateTimeField"</code> should contain Records, with keys corresponding to codes listed in  <emu-xref href="#table-validcodefordatetimefield" id="_ref_5"><a href="#table-validcodefordatetimefield">Table 1</a></emu-xref>. The value of these fields must be string values.</ins></li>
         <li><ins>The display name styles fields under display name type <code>"unit"</code> should contain Records, with keys corresponding to a well-formed core unit identifier as defined in UTS #35, Part 2, Section 6.. The value of these fields must be string values.</ins></li>
       </ul>
 
       <emu-note><span class="note">Note</span><div class="note-contents">
-        It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>).
+        It is recommended that implementations use the locale data provided by the Common Locale Data Repository (available at  <a href="http://cldr.unicode.org/">http://cldr.unicode.org/</a>).
+      
       </div></emu-note>
     </emu-clause>
   </emu-clause>
 
   <emu-clause id="sec-properties-of-intl-displaynames-prototype-object">
-    <h1><span class="secnum">1.5</span> Properties of the Intl.DisplayNames Prototype Object</h1>
+    <h1><span class="secnum">1.5</span>Properties of the Intl.DisplayNames Prototype Object</h1>
 
     <p>
       The Intl.DisplayNames prototype object, referred to as <emu-val>%DisplayNamesPrototype%</emu-val>, is itself an ordinary object. It is not a Intl.DisplayNames instance, does not have an [[InitializedDisplayNames]] internal slot or any of the other internal slots of Intl.DisplayNames instance objects.
+    
     </p>
 
     <emu-clause id="sec-Intl.DisplayNames.prototype.constructor">
-      <h1><span class="secnum">1.5.1</span> Intl.DisplayNames.prototype.constructor</h1>
+      <h1><span class="secnum">1.5.1</span>Intl.DisplayNames.prototype.constructor</h1>
 
       <p>
         The initial value of <emu-val>Intl.DisplayNames.prototype.constructor</emu-val> is the intrinsic object <emu-val>%DisplayNames%</emu-val>.
+      
       </p>
     </emu-clause>
 
     <emu-clause id="sec-Intl.DisplayNames.prototype-@@tostringtag">
-      <h1><span class="secnum">1.5.2</span> Intl.DisplayNames.prototype[ @@toStringTag ]</h1>
+      <h1><span class="secnum">1.5.2</span>Intl.DisplayNames.prototype[ @@toStringTag ]</h1>
 
       <p>
         The initial value of the @@toStringTag property is the string value <code>"Intl.DisplayNames"</code>.
+      
       </p>
       <p>
         This property has the attributes { [[Writable]]: <emu-val>false</emu-val>, [[Enumerable]]: <emu-val>false</emu-val>, [[Configurable]]: <emu-val>true</emu-val> }.
+      
       </p>
     </emu-clause>
 
     <emu-clause id="sec-Intl.DisplayNames.prototype.of" aoid="Intl.DisplayNames.prototype.of">
-      <h1><span class="secnum">1.5.3</span> Intl.DisplayNames.prototype.of ( <var>code</var> )</h1>
+      <h1><span class="secnum">1.5.3</span>Intl.DisplayNames.prototype.of ( <var>code</var> )</h1>
 
       <p>
         When the <emu-val>Intl.DisplayNames.prototype.of</emu-val> is called with an argument <var>code</var>, the following steps are taken:
+      
       </p>
 
-      <emu-alg><ol><li>Let <var>displayNames</var> be <emu-val>this</emu-val> value.</li><li>If <emu-xref aoid="Type" id="_ref_11"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>displayNames</var>) is not Object, throw a <emu-val>TypeError</emu-val> exception.</li><li>If <var>displayNames</var> does not have an [[InitializedDisplayNames]] internal slot, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>code</var> be ?&nbsp;<emu-xref aoid="ToString" id="_ref_12"><a href="https://tc39.es/ecma262/#sec-tostring">ToString</a></emu-xref>(<var>code</var>).</li><li>Let <var>code</var> be ?&nbsp;<emu-xref aoid="CanonicalCodeForDisplayNames" id="_ref_13"><a href="#sec-canonicalcodefordisplaynames">CanonicalCodeForDisplayNames</a></emu-xref>(<var>displayNames</var>.[[Type]], <var>code</var>).</li><li>Let <var>fields</var> be <var>displayNames</var>.[[Fields]].</li><li>Let <var>name</var> be <var>fields</var>[[&lt;<var>code</var>&gt;]].</li><li>If <var>name</var> is not <emu-val>undefined</emu-val>, return <var>name</var>.</li><li>If <var>displayNames</var>.[[Fallback]] is <code>"code"</code>, return <var>code</var>.</li><li>Return <emu-val>undefined</emu-val>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>displayNames</var> be <emu-val>this</emu-val> value.</li><li>If <emu-xref aoid="Type" id="_ref_11"><a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>displayNames</var>) is not Object, throw a <emu-val>TypeError</emu-val> exception.</li><li>If <var>displayNames</var> does not have an [[InitializedDisplayNames]] internal slot, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>code</var> be ?&nbsp;<emu-xref aoid="ToString" id="_ref_12"><a href="https://tc39.github.io/ecma262/#sec-tostring">ToString</a></emu-xref>(<var>code</var>).</li><li>Let <var>code</var> be ?&nbsp;<emu-xref aoid="CanonicalCodeForDisplayNames" id="_ref_13"><a href="#sec-canonicalcodefordisplaynames">CanonicalCodeForDisplayNames</a></emu-xref>(<var>displayNames</var>.[[Type]], <var>code</var>).</li><li>Let <var>fields</var> be <var>displayNames</var>.[[Fields]].</li><li>Let <var>name</var> be <var>fields</var>[[&lt;<var>code</var>&gt;]].</li><li>If <var>name</var> is not <emu-val>undefined</emu-val>, return <var>name</var>.</li><li>If <var>displayNames</var>.[[Fallback]] is <code>"code"</code>, return <var>code</var>.</li><li>Return <emu-val>undefined</emu-val>.
+      </li></ol></emu-alg>
     </emu-clause>
 
     <emu-clause id="sec-Intl.DisplayNames.prototype.resolvedOptions">
-      <h1><span class="secnum">1.5.4</span> Intl.DisplayNames.prototype.resolvedOptions ( )</h1>
+      <h1><span class="secnum">1.5.4</span>Intl.DisplayNames.prototype.resolvedOptions ( )</h1>
 
       <p>
         This function provides access to the locale and options computed during initialization of the object.
+      
       </p>
 
-      <emu-alg><ol><li>Let <var>displayNames</var> be <emu-val>this</emu-val> value.</li><li>If <emu-xref aoid="Type" id="_ref_14"><a href="https://tc39.es/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>displayNames</var>) is not Object, throw a <emu-val>TypeError</emu-val> exception.</li><li>If <var>displayNames</var> does not have an [[InitializedDisplayNames]] internal slot, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>options</var> be !&nbsp;<emu-xref aoid="ObjectCreate" id="_ref_15"><a href="https://tc39.es/ecma262/#sec-objectcreate">ObjectCreate</a></emu-xref>(<emu-xref href="#sec-properties-of-the-object-prototype-object"><a href="https://tc39.es/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a></emu-xref>).</li><li>For each row of <emu-xref href="#table-displaynames-resolvedoptions-properties" id="_ref_6"><a href="#table-displaynames-resolvedoptions-properties">Table 2</a></emu-xref>, except the header row, in table order, do<ol><li>Let <var>p</var> be the Property value of the current row.</li><li>Let <var>v</var> be the value of <var>displayNames</var>'s internal slot whose name is the Internal Slot value of the current row.</li><li>If <var>v</var> is not <emu-val>undefined</emu-val>, then<ol><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_16"><a href="https://tc39.es/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>options</var>, <var>p</var>, <var>v</var>).</li></ol></li></ol></li><li>Return <var>options</var>.</li></ol></emu-alg>
+      <emu-alg><ol><li>Let <var>displayNames</var> be <emu-val>this</emu-val> value.</li><li>If <emu-xref aoid="Type" id="_ref_14"><a href="https://tc39.github.io/ecma262/#sec-ecmascript-data-types-and-values">Type</a></emu-xref>(<var>displayNames</var>) is not Object, throw a <emu-val>TypeError</emu-val> exception.</li><li>If <var>displayNames</var> does not have an [[InitializedDisplayNames]] internal slot, throw a <emu-val>TypeError</emu-val> exception.</li><li>Let <var>options</var> be !&nbsp;<emu-xref aoid="ObjectCreate" id="_ref_15"><a href="https://tc39.github.io/ecma262/#sec-objectcreate">ObjectCreate</a></emu-xref>(<emu-xref href="#sec-properties-of-the-object-prototype-object"><a href="https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object">%ObjectPrototype%</a></emu-xref>).</li><li>For each row of <emu-xref href="#table-displaynames-resolvedoptions-properties" id="_ref_6"><a href="#table-displaynames-resolvedoptions-properties">Table 2</a></emu-xref>, except the header row, in table order, do<ol><li>Let <var>p</var> be the Property value of the current row.</li><li>Let <var>v</var> be the value of <var>displayNames</var>'s internal slot whose name is the Internal Slot value of the current row.</li><li>If <var>v</var> is not <emu-val>undefined</emu-val>, then<ol><li>Perform !&nbsp;<emu-xref aoid="CreateDataPropertyOrThrow" id="_ref_16"><a href="https://tc39.github.io/ecma262/#sec-createdatapropertyorthrow">CreateDataPropertyOrThrow</a></emu-xref>(<var>options</var>, <var>p</var>, <var>v</var>).</li></ol></li></ol></li><li>Return <var>options</var>.
+      </li></ol></emu-alg>
 
       <emu-table id="table-displaynames-resolvedoptions-properties"><figure><figcaption>Table 2: Resolved Options of DisplayNames Instances</figcaption>
         
@@ -2107,32 +2085,35 @@ li.menu-search-result-term:before {
   </emu-clause>
 
   <emu-clause id="sec-properties-of-intl-displaynames-instances">
-    <h1><span class="secnum">1.6</span> Properties of Intl.DisplayNames Instances</h1>
+    <h1><span class="secnum">1.6</span>Properties of Intl.DisplayNames Instances</h1>
 
     <p>
       Intl.DisplayNames instances are ordinary objects that inherit properties from %DisplayNamesPrototype%.
+    
     </p>
 
     <p>
       Intl.DisplayNames instances have an [[InitializedDisplayNames]] internal slot.
+    
     </p>
 
     <p>
-      Intl.DisplayNames instances also have several internal slots that are computed by the <emu-xref href="#constructor"><a href="https://tc39.es/ecma262/#constructor">constructor</a></emu-xref>:
+      Intl.DisplayNames instances also have several internal slots that are computed by the constructor:
+    
     </p>
 
     <ul>
       <li>[[Locale]] is a String value with the language tag of the locale whose localization is used for formatting.</li>
       <li>[[Style]] is one of the String values <code>"narrow"</code>, <code>"short"</code>, or <code>"long"</code>, identifying the display names style used.</li>
-      <li>[[Type]] is one of the String values <code>"language"</code>, <code>"region"</code>, <code>"script"</code>, <del>or </del><code>"currency"</code>,<ins> <code>"calendar"</code>, <code>"dateTimeField"</code>, or <code>"unit"</code>,</ins> identifying the type of the display names requested.</li>
+      <li>[[Type]] is one of the String values <code>"language"</code>, <code>"region"</code>, <code>"script"</code>,  <del>or  </del><code>"currency"</code>,<ins> <code>"calendar"</code>, <code>"dateTimeField"</code>, or <code>"unit"</code>,</ins> identifying the type of the display names requested.</li>
       <li>[[Fallback]] is one of the String values <code>"code"</code>, or <code>"none"</code>, identifying the fallback return when the system does not have the requested display name.</li>
-      <li><ins>[[DialectHandling]] is one of the String values <code>"dialectName"</code>, or <code>"standardName"</code>, identifying the display names dialect handling while and only while the [[Type]] is <code>"language"</code>.</ins></li>
-      <li>[[Fields]] is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.es/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see <emu-xref href="#sec-Intl.DisplayNames-internal-slots" id="_ref_7"><a href="#sec-Intl.DisplayNames-internal-slots">1.4.3</a></emu-xref>) which
-        must have fields with keys corresponding to codes according to [[Style]] <del>and</del><ins>,</ins> [[Type]]<ins>, and [[DialectHandling]]</ins>.</li>
+      <li><ins>[[DialectHandling]] is one of the String values <code>"dialect"</code>, or <code>"standard"</code>, identifying the display names dialect handling while and only while the [[Type]] is <code>"language"</code>.</ins></li>
+      <li>[[Fields]] is a <emu-xref href="#sec-list-and-record-specification-type"><a href="https://tc39.github.io/ecma262/#sec-list-and-record-specification-type">Record</a></emu-xref> (see  <emu-xref href="#sec-Intl.DisplayNames-internal-slots" id="_ref_7"><a href="#sec-Intl.DisplayNames-internal-slots">1.4.3</a></emu-xref>) which
+        must have fields with keys corresponding to codes according to [[Style]]  <del>and</del><ins>,</ins> [[Type]]<ins>, and [[DialectHandling]]</ins>.</li>
     </ul>
   </emu-clause>
 </emu-clause><emu-annex id="sec-copyright-and-software-license">
-      <h1><span class="secnum">A</span> Copyright &amp; Software License</h1>
+      <h1><span class="secnum">A</span>Copyright &amp; Software License</h1>
       
       <h2>Copyright Notice</h2>
       <p>© 2021 Google, Ecma International</p>
@@ -2150,5 +2131,6 @@ li.menu-search-result-term:before {
 
 <p>THIS SOFTWARE IS PROVIDED BY THE ECMA INTERNATIONAL "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL ECMA INTERNATIONAL BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
 
-    </emu-annex></emu-import>
+    </emu-annex>
+</emu-import>
 </div></body>


### PR DESCRIPTION
Address https://github.com/tc39/intl-displaynames-v2/issues/29
Since @anba wrote 
>And because SpiderMonkey uses a different default and because we didn't yet receive any web-compatibility bug reports, it seems possible to use either value as the default in ECMA-402.

and @ryzokuken 
>I talked to @zbraniecki about this briefly and as @anba pointed out too, there aren't any bug reports about the inconsistency so it would be fine in my opinion to switch either way.

@codehag 
>The default is currently, "dialect" and SM would be happy to align.

I believe this PR could close #29 
